### PR TITLE
fix panic

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -234,11 +234,16 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}))
 
 	case message.AddContextualKeyBindingsMsg:
-		m.activeKeys.ToggleContextual(msg.Bindings)
+		if m.activeKeys != nil {
+			m.activeKeys.ToggleContextual(msg.Bindings)
+		}
+
 		return m, nil
 
 	case message.ClearContextualKeyBindingsMsg:
-		m.activeKeys.DisableContextual()
+		if m.activeKeys != nil {
+			m.activeKeys.DisableContextual()
+		}
 		return m, nil
 
 	case tea.KeyMsg:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 
 	"github.com/GustavoCaso/docker-dash/internal/client"
 	"github.com/GustavoCaso/docker-dash/internal/config"
+	"github.com/GustavoCaso/docker-dash/internal/ui/message"
 )
 
 func TestFullOutput(t *testing.T) {
@@ -248,6 +250,18 @@ func TestConfirmationModalConfirmDeletesImage(t *testing.T) {
 
 	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
+}
+
+func TestContextualKeyBindingsBeforeViewRender(t *testing.T) {
+	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+
+	// Send AddContextualKeyBindingsMsg before activeKeys is set — must not panic.
+	m.Update(message.AddContextualKeyBindingsMsg{
+		Bindings: []key.Binding{key.NewBinding(key.WithKeys("x"))},
+	})
+
+	// Send ClearContextualKeyBindingsMsg before activeKeys is set — must not panic.
+	m.Update(message.ClearContextualKeyBindingsMsg{})
 }
 
 func waitForString(t *testing.T, tm *teatest.TestModel, s string) {


### PR DESCRIPTION
Fix panic:

```
Config file not present. Using default values
Caught panic:

runtime error: invalid memory address or nil pointer dereference

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
	/Users/gustavocaso/.local/share/mise/installs/go/1.25.0/src/runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
	/Users/gustavocaso/.local/share/mise/installs/go/1.25.0/src/runtime/debug/stack.go:18 +0x1c
github.com/charmbracelet/bubbletea.(*Program).recoverFromPanic(0x140001a4280, {0x102e27680, 0x1031eb390})
	/Users/gustavocaso/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:847 +0x90
github.com/charmbracelet/bubbletea.(*Program).Run.func2()
	/Users/gustavocaso/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:638 +0xc4
panic({0x102e27680?, 0x1031eb390?})
	/Users/gustavocaso/.local/share/mise/installs/go/1.25.0/src/runtime/panic.go:783 +0x120
github.com/GustavoCaso/docker-dash/internal/ui/keys.(*ViewKeyMap).ToggleContextual(...)
	/Users/gustavocaso/src/github.com/GustavoCaso/docker-dash/internal/ui/keys/keys.go:169
github.com/GustavoCaso/docker-dash/internal/ui.(*model).Update(0x14000378000, {0x102e3e280, 0x1400000c0d8})
	/Users/gustavocaso/src/github.com/GustavoCaso/docker-dash/internal/ui/app.go:237 +0x830
github.com/charmbracelet/bubbletea.(*Program).eventLoop(0x140001a4280, {0x102ec28f0?, 0x14000378000?}, 0x140001842a0)
	/Users/gustavocaso/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:494 +0x674
github.com/charmbracelet/bubbletea.(*Program).Run(0x140001a4280)
	/Users/gustavocaso/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:716 +0x840
main.main()
	/Users/gustavocaso/src/github.com/GustavoCaso/docker-dash/cmd/docker-dash/main.go:65 +0x328
Error: program was killed: program experienced a panic
exit status 1
```

The issue is a race condition in the app initialization process in which any of the section could send a command that could change the activeKeys bindings. 

The solution is to guards by checking if `activeKeys` is not nil when handling the binding message