### PR TITLE
Ensure that logs streams works 

### DIFF
--- a/internal/client/docker.go
+++ b/internal/client/docker.go
@@ -353,8 +353,7 @@ func (s *containerService) Logs(ctx context.Context, id string, opts LogOptions)
 
 	pr, pw := io.Pipe()
 	go func() {
-		_, copyErr := stdcopy.StdCopy(pw, pw, reader)
-		pw.CloseWithError(copyErr)
+		pw.CloseWithError(copyStream(pw, reader))
 	}()
 
 	log.Printf("[docker] ContainerLogs: session created")
@@ -362,6 +361,32 @@ func (s *containerService) Logs(ctx context.Context, id string, opts LogOptions)
 		io.NopCloser(pr),
 		func() { _ = reader.Close() },
 	), nil
+}
+
+// maxMuxStreamType is the highest valid STREAM_TYPE value in Docker's multiplexed stream format.
+// Per the Docker API docs: 0=stdin, 1=stdout, 2=stderr.
+// Frames start with an 8-byte header: [STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4].
+const maxMuxStreamType = 0x02
+
+// copyStream detects whether r is a Docker multiplexed stream or a raw stream,
+// then copies accordingly. This handles engines like OrbStack and Colima that
+// may not use Docker's multiplexed format.
+func copyStream(w io.Writer, r io.Reader) error {
+	var streamType [1]byte
+	_, err := io.ReadFull(r, streamType[:])
+	if err != nil {
+		return err
+	}
+
+	full := io.MultiReader(strings.NewReader(string(streamType[:])), r)
+
+	if streamType[0] <= maxMuxStreamType {
+		_, err = stdcopy.StdCopy(w, w, full)
+	} else {
+		log.Printf("[docker] ContainerLogs: raw stream detected (first byte=0x%02x), using io.Copy", streamType[0])
+		_, err = io.Copy(w, full)
+	}
+	return err
 }
 
 func (s *containerService) Exec(ctx context.Context, id string) (*ExecSession, error) {

--- a/internal/client/docker_test.go
+++ b/internal/client/docker_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"archive/tar"
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
 	"testing"
@@ -306,6 +307,82 @@ func TestBuildContainerFileTree_ComplexTree(t *testing.T) {
 	}
 	if appConf.Depth != 3 {
 		t.Errorf("'app.conf' depth: got %d, want 3", appConf.Depth)
+	}
+}
+
+// buildMuxFrame builds a Docker multiplexed-stream frame for the given streamType and payload.
+// Frame format: [streamType, 0, 0, 0, size(4 bytes big-endian), payload...].
+func buildMuxFrame(streamType byte, payload []byte) []byte {
+	frame := make([]byte, 8+len(payload))
+	frame[0] = streamType
+	binary.BigEndian.PutUint32(frame[4:], uint32(len(payload)))
+	copy(frame[8:], payload)
+	return frame
+}
+
+func TestCopyStreamRaw(t *testing.T) {
+	// First byte > 0x02 → raw stream, io.Copy is used.
+	data := []byte{0x03, 'h', 'e', 'l', 'l', 'o'}
+	var buf bytes.Buffer
+	err := copyStream(&buf, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("copyStream() raw error: %v", err)
+	}
+	if !bytes.Equal(buf.Bytes(), data) {
+		t.Errorf("copyStream() raw output = %q, want %q", buf.Bytes(), data)
+	}
+}
+
+func TestCopyStreamMuxStdout(t *testing.T) {
+	// First byte == 0x01 (stdout) → Docker multiplexed format.
+	payload := []byte("hello logs")
+	frame := buildMuxFrame(0x01, payload)
+	var buf bytes.Buffer
+	err := copyStream(&buf, bytes.NewReader(frame))
+	if err != nil {
+		t.Fatalf("copyStream() mux error: %v", err)
+	}
+	if !bytes.Equal(buf.Bytes(), payload) {
+		t.Errorf("copyStream() mux output = %q, want %q", buf.Bytes(), payload)
+	}
+}
+
+func TestCopyStreamMuxStderr(t *testing.T) {
+	// First byte == 0x02 (stderr) → Docker multiplexed format, written to same writer.
+	payload := []byte("error output")
+	frame := buildMuxFrame(0x02, payload)
+	var buf bytes.Buffer
+	err := copyStream(&buf, bytes.NewReader(frame))
+	if err != nil {
+		t.Fatalf("copyStream() mux stderr error: %v", err)
+	}
+	if !bytes.Equal(buf.Bytes(), payload) {
+		t.Errorf("copyStream() mux stderr output = %q, want %q", buf.Bytes(), payload)
+	}
+}
+
+func TestCopyStreamEmptyReader(t *testing.T) {
+	// Empty reader → io.ReadFull returns io.ErrUnexpectedEOF (or io.EOF for 0 bytes).
+	var buf bytes.Buffer
+	err := copyStream(&buf, bytes.NewReader(nil))
+	if err == nil {
+		t.Fatal("copyStream() on empty reader should return an error")
+	}
+}
+
+func TestCopyStreamMuxMultipleFrames(t *testing.T) {
+	// Multiple frames: stdout then stderr, both written to the same writer.
+	var input bytes.Buffer
+	input.Write(buildMuxFrame(0x01, []byte("line1\n")))
+	input.Write(buildMuxFrame(0x02, []byte("line2\n")))
+	var buf bytes.Buffer
+	err := copyStream(&buf, &input)
+	if err != nil {
+		t.Fatalf("copyStream() multiple frames error: %v", err)
+	}
+	got := buf.String()
+	if got != "line1\nline2\n" {
+		t.Errorf("copyStream() multiple frames = %q, want %q", got, "line1\nline2\n")
 	}
 }
 

--- a/internal/ui/sections/networks/details_panel.go
+++ b/internal/ui/sections/networks/details_panel.go
@@ -26,7 +26,7 @@ func newDetailsPanel() panel.Panel {
 }
 
 func (d *detailsPanel) Init(content string) tea.Cmd {
-	log.Printf("[network][details-panel] Init: networkID=%q", content)
+	log.Print("[network][details-panel] Init")
 	d.viewport.SetContent(content)
 	return nil
 }


### PR DESCRIPTION
By checking the first byte and validate if is in docker stream format or not:

Docker stream format is:
```
[STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4].
```

Extracted documentation from https://docs.docker.com/reference/api/engine/version/v1.53/#tag/Container/operation/ContainerAttach