### PR TITLE
Make sure to reset active panel when removing last item of the list 

### DIFF
--- a/internal/ui/sections/containers/section.go
+++ b/internal/ui/sections/containers/section.go
@@ -333,9 +333,10 @@ func (s *Section) activePanel() panel.Panel {
 
 func (s *Section) removeItem(idx int) tea.Cmd {
 	s.list.RemoveItem(idx)
-	if len(s.list.Items()) > 0 {
-		s.list.Select(min(idx, len(s.list.Items())-1))
+	if len(s.list.Items()) == 0 {
+		return s.activePanel().Close()
 	}
+	s.list.Select(min(idx, len(s.list.Items())-1))
 	return s.updateActivePanel()
 }
 

--- a/internal/ui/sections/containers/section_test.go
+++ b/internal/ui/sections/containers/section_test.go
@@ -313,25 +313,26 @@ func TestContainerDeleteUpdatesSelection(t *testing.T) {
 	}
 }
 
-func TestContainerDeleteLastItemClampsSelection(t *testing.T) {
+func TestContainerDeleteLastItemClearsPanel(t *testing.T) {
 	c := client.NewMockClient()
 	containers, _ := c.Containers().List(context.Background())
-	section := New(context.Background(), containers, c.Containers())
+
+	// Create a section with a single container so we can test the empty-list path.
+	singleContainer := containers[:1]
+	section := New(context.Background(), singleContainer, c.Containers())
 	section.SetSize(120, 40)
 
-	if len(section.list.Items()) == 0 {
-		t.Fatal("expected at least one container in mock data")
-	}
+	// Set content on the default details panel so we can verify it gets cleared.
+	dp := section.panels[0].(*detailsPanel)
+	dp.viewport.SetContent("stale container details")
 
-	// Delete all but the last item without checking cmd type (items still remain)
-	for len(section.list.Items()) > 1 {
-		section.removeItem(0)
-	}
-
-	// Delete the final item — no selected item remains, so cmd must be nil
+	// Delete the single item — activePanel().Close() should be called.
 	cmd := section.removeItem(0)
 	if cmd != nil {
-		t.Error("removeItem() should return nil cmd when list is empty")
+		t.Error("removeItem() should return nil cmd when list is empty (Close() returns nil)")
+	}
+	if strings.TrimSpace(dp.viewport.View()) != "" {
+		t.Error("deleteLastItem() should clear the panel viewport content")
 	}
 }
 

--- a/internal/ui/sections/images/section.go
+++ b/internal/ui/sections/images/section.go
@@ -288,31 +288,7 @@ func (s *Section) Update(msg tea.Msg) tea.Cmd {
 			s.loading = true
 			return tea.Batch(s.spinner.Tick, s.updateImagesCmd())
 		case key.Matches(msg, keys.Keys.PullImage):
-			f := huh.NewForm(
-				huh.NewGroup(
-					huh.NewInput().
-						Key("image").
-						Title("Image").
-						Validate(func(s string) error {
-							if strings.TrimSpace(s) == "" {
-								return errors.New("image name cannot be empty")
-							}
-							return nil
-						}),
-
-					huh.NewSelect[string]().
-						Key("platform").
-						Title("Platform").
-						Options(
-							huh.NewOption("auto", ""),
-							huh.NewOption("linux/amd64", "linux/amd64"),
-							huh.NewOption("linux/arm64", "linux/arm64"),
-							huh.NewOption("linux/arm/v7", "linux/arm/v7"),
-							huh.NewOption("linux/386", "linux/386"),
-							huh.NewOption("windows/amd64", "windows/amd64"),
-						),
-				),
-			)
+			f := pullImageForm()
 
 			pullForm := form.New("Pull Image", f, func(finishForm *huh.Form) tea.Cmd {
 				image := finishForm.GetString("image")
@@ -530,9 +506,10 @@ func (s *Section) activePanel() panel.Panel {
 
 func (s *Section) removeItem(idx int) tea.Cmd {
 	s.list.RemoveItem(idx)
-	if len(s.list.Items()) > 0 {
-		s.list.Select(min(idx, len(s.list.Items())-1))
+	if len(s.list.Items()) == 0 {
+		return s.activePanel().Close()
 	}
+	s.list.Select(min(idx, len(s.list.Items())-1))
 	return s.updateActivePanel()
 }
 
@@ -546,4 +523,32 @@ func (s *Section) updateActivePanel() tea.Cmd {
 		return nil
 	}
 	return s.activePanel().Init(item.ID())
+}
+
+func pullImageForm() *huh.Form {
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Key("image").
+				Title("Image").
+				Validate(func(s string) error {
+					if strings.TrimSpace(s) == "" {
+						return errors.New("image name cannot be empty")
+					}
+					return nil
+				}),
+
+			huh.NewSelect[string]().
+				Key("platform").
+				Title("Platform").
+				Options(
+					huh.NewOption("auto", ""),
+					huh.NewOption("linux/amd64", "linux/amd64"),
+					huh.NewOption("linux/arm64", "linux/arm64"),
+					huh.NewOption("linux/arm/v7", "linux/arm/v7"),
+					huh.NewOption("linux/386", "linux/386"),
+					huh.NewOption("windows/amd64", "windows/amd64"),
+				),
+		),
+	)
 }

--- a/internal/ui/sections/images/section_test.go
+++ b/internal/ui/sections/images/section_test.go
@@ -338,25 +338,26 @@ func TestImageDeleteUpdatesSelection(t *testing.T) {
 	}
 }
 
-func TestImageDeleteLastItemClampsSelection(t *testing.T) {
+func TestImageDeleteLastItemClearsPanel(t *testing.T) {
 	c := client.NewMockClient()
 	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c)
+
+	// Create a section with a single image so we can test the empty-list path.
+	singleImage := images[:1]
+	section := New(context.Background(), singleImage, c)
 	section.SetSize(120, 40)
 
-	if len(section.list.Items()) == 0 {
-		t.Fatal("expected at least one image in mock data")
-	}
+	// Set content on the layers panel so we can verify it gets cleared.
+	lp := section.panels[0].(*layersPanel)
+	lp.viewport.SetContent("stale layer info")
 
-	// Delete all but the last item without checking cmd type (items still remain)
-	for len(section.list.Items()) > 1 {
-		section.removeItem(0)
-	}
-
-	// Delete the final item — no selected item remains, so cmd must be nil
+	// Delete the single item — activePanel().Close() should be called.
 	cmd := section.removeItem(0)
 	if cmd != nil {
-		t.Error("removeItem() should return nil cmd when list is empty")
+		t.Error("removeItem() should return nil cmd when list is empty (Close() returns nil)")
+	}
+	if strings.TrimSpace(lp.viewport.View()) != "" {
+		t.Error("deleteLastItem() should clear the panel viewport content")
 	}
 }
 

--- a/internal/ui/sections/networks/section.go
+++ b/internal/ui/sections/networks/section.go
@@ -304,9 +304,10 @@ func (s *Section) activePanel() panel.Panel {
 
 func (s *Section) removeItem(idx int) tea.Cmd {
 	s.list.RemoveItem(idx)
-	if len(s.list.Items()) > 0 {
-		s.list.Select(min(idx, len(s.list.Items())-1))
+	if len(s.list.Items()) == 0 {
+		return s.activePanel().Close()
 	}
+	s.list.Select(min(idx, len(s.list.Items())-1))
 	return s.updateActivePanel()
 }
 

--- a/internal/ui/sections/networks/section_test.go
+++ b/internal/ui/sections/networks/section_test.go
@@ -169,19 +169,26 @@ func TestNetworkDeleteUpdatesSelection(t *testing.T) {
 	}
 }
 
-func TestNetworkDeleteLastItemClampsSelection(t *testing.T) {
+func TestNetworkDeleteLastItemClearsPanel(t *testing.T) {
 	c := client.NewMockClient()
 	networks, _ := c.Networks().List(context.Background())
-	section := New(context.Background(), networks, c.Networks())
+
+	// Create a section with a single network so we can test the empty-list path.
+	singleNetwork := networks[:1]
+	section := New(context.Background(), singleNetwork, c.Networks())
 	section.SetSize(120, 40)
 
-	if len(section.list.Items()) == 0 {
-		t.Fatal("expected at least one network in mock data")
-	}
+	// Set content on the details panel so we can verify it gets cleared.
+	dp := section.panels[0].(*detailsPanel)
+	dp.viewport.SetContent("stale network details")
 
-	// Delete all items — detailsPanel.Init() always returns nil (sync panel)
-	for len(section.list.Items()) > 0 {
-		section.removeItem(0)
+	// Delete the single item — activePanel().Close() should be called.
+	cmd := section.removeItem(0)
+	if cmd != nil {
+		t.Error("removeItem() should return nil cmd when list is empty (Close() returns nil)")
+	}
+	if strings.TrimSpace(dp.viewport.View()) != "" {
+		t.Error("deleteLastItem() should clear the panel viewport content")
 	}
 }
 


### PR DESCRIPTION
When removing an items from the section list
There is the edge case of deleting the last item.
Prior we simply update the activePanel for the active item, but deleting the last item was causing to return early leaving stale information.

When removing the last item we close the current active panel to clear the view