### PR TITLE
Update Goreleaser to split builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,13 +16,25 @@ builds:
     goos:
       - linux
       - windows
-      - darwin
     goarch:
       - amd64
       - arm64
     ignore:
       - goos: windows
         goarch: arm64
+  - id: docker-dash-darwin
+    main: ./cmd/docker-dash
+    binary: docker-dash
+    env:
+      - CGO_ENABLED=1
+    ldflags:
+      - "-s -w"
+      - -X main.Version={{.Tag}}
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
 
 archives:
   - formats:


### PR DESCRIPTION
Need to enable CGO for Darwin binary as github.com/fsnotify/fsevents@v0.2.0 for Darwin requires it 