### PR TITLE
Add homebrew post-install hook to run xattr

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,3 +71,9 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/GustavoCaso/docker-dash"
     description: "Terminal UI dashboard for managing Docker containers, images, volumes, and networks"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/docker-dash"]
+          end


### PR DESCRIPTION
Add post-install hook to remove quarantine attribute on macOS.
If not done, macOS will not trust the binary and move it to the bin.
I am doing it [here](https://github.com/hilli/go-kef-w2/blob/main/.goreleaser.yaml) without user complaints.