### PR TITLE
Add container pause and unpause support 

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -75,6 +75,8 @@ type ContainerService interface {
 	Exec(ctx context.Context, id string) (*ExecSession, error)
 	Stats(ctx context.Context, is string) (*StatsSession, error)
 	Prune(ctx context.Context, opts PruneOptions) (PruneReport, error)
+	Pause(ctx context.Context, id string) error
+	Unpause(ctx context.Context, id string) error
 }
 
 // ImageService manages Docker images.

--- a/internal/client/docker_container_service.go
+++ b/internal/client/docker_container_service.go
@@ -286,6 +286,20 @@ func (s *containerService) Remove(ctx context.Context, id string, force bool) er
 	return err
 }
 
+func (s *containerService) Pause(ctx context.Context, id string) error {
+	log.Printf("[docker] ContainerPause: id=%q", id)
+	err := s.cli.ContainerPause(ctx, id)
+	log.Printf("[docker] ContainerPause: done err=%v", err)
+	return err
+}
+
+func (s *containerService) Unpause(ctx context.Context, id string) error {
+	log.Printf("[docker] ContainerUnpause: id=%q", id)
+	err := s.cli.ContainerUnpause(ctx, id)
+	log.Printf("[docker] ContainerUnpause: done err=%v", err)
+	return err
+}
+
 const logsSinceHours = 2 // hours of log history to fetch
 
 func (s *containerService) Logs(ctx context.Context, id string, opts LogOptions) (*LogsSession, error) {

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -250,6 +250,30 @@ func (s *mockContainerService) Stop(ctx context.Context, id string) error {
 	return fmt.Errorf("container not found: %s", id)
 }
 
+func (s *mockContainerService) Pause(ctx context.Context, containerID string) error {
+	for i, c := range s.containers {
+		if c.ID == containerID || c.Name == containerID {
+			s.containers[i].State = StatePaused
+			s.containers[i].Status = "Up 16 seconds (Paused)"
+			return nil
+		}
+	}
+
+	return fmt.Errorf("container not found: %s", containerID)
+}
+
+func (s *mockContainerService) Unpause(ctx context.Context, containerID string) error {
+	for i, c := range s.containers {
+		if c.ID == containerID || c.Name == containerID {
+			s.containers[i].State = StateRunning
+			s.containers[i].Status = "Up 34 seconds"
+			return nil
+		}
+	}
+
+	return fmt.Errorf("container not found: %s", containerID)
+}
+
 func (s *mockContainerService) Restart(ctx context.Context, id string) error {
 	for i, c := range s.containers {
 		if c.ID == id || c.Name == id {

--- a/internal/ui/keys/keys.go
+++ b/internal/ui/keys/keys.go
@@ -22,9 +22,10 @@ type KeyMap struct {
 	CreateAndRunContainer key.Binding
 	PullImage             key.Binding
 
-	ContainerDelete    key.Binding
-	ContainerStartStop key.Binding
-	ContainerRestart   key.Binding
+	ContainerDelete       key.Binding
+	ContainerStartStop    key.Binding
+	ContainerRestart      key.Binding
+	ContainerPauseUnpause key.Binding
 
 	ComposeUp        key.Binding
 	ComposeDown      key.Binding
@@ -134,6 +135,10 @@ var Keys = &KeyMap{
 		key.WithKeys("ctrl+R"),
 		key.WithHelp("ctrl+R", "restart container"),
 	),
+	ContainerPauseUnpause: key.NewBinding(
+		key.WithKeys("p"),
+		key.WithHelp("p", "pause/unpause container"),
+	),
 	ComposeUp: key.NewBinding(
 		key.WithKeys("u"),
 		key.WithHelp("u", "compose up"),
@@ -219,7 +224,7 @@ func (k KeyMap) ContainerKeyMap() *ViewKeyMap {
 			{k.Left, k.Right, k.PanelNext, k.PanelPrev},
 			{k.Up, k.Down, k.ScrollUp, k.ScrollDown},
 			{k.ContainerDelete, k.ContainerStartStop, k.ContainerRestart, k.Prune},
-			{k.Filter, k.Help, k.Quit},
+			{k.ContainerPauseUnpause, k.Filter, k.Help, k.Quit},
 		},
 		contextualKeys: []key.Binding{},
 	}

--- a/internal/ui/sections/containers/section.go
+++ b/internal/ui/sections/containers/section.go
@@ -170,7 +170,9 @@ func (s *Section) handleMsg(msg tea.Msg) base.UpdateResult {
 		if msg.Action == "deleting" {
 			cmds = append(cmds, s.RemoveItemAndUpdatePanel(msg.Idx))
 		}
-		if msg.Action == "starting" || msg.Action == "stopping" || msg.Action == "restarting" || msg.Action == "pausing" || msg.Action == "unpausing" {
+		if msg.Action == "starting" || msg.Action == "stopping" || msg.Action == "restarting" ||
+			msg.Action == "pausing" ||
+			msg.Action == "unpausing" {
 			cmds = append(cmds, s.updateContainersCmd())
 			stopSpinner = false
 		}
@@ -435,5 +437,4 @@ func (s *Section) confirmContainerPauseUnpause() tea.Cmd {
 			OnConfirm: s.WithSpinner(pauseUnpauseCmd),
 		}
 	}
-
 }

--- a/internal/ui/sections/containers/section.go
+++ b/internal/ui/sections/containers/section.go
@@ -170,7 +170,7 @@ func (s *Section) handleMsg(msg tea.Msg) base.UpdateResult {
 		if msg.Action == "deleting" {
 			cmds = append(cmds, s.RemoveItemAndUpdatePanel(msg.Idx))
 		}
-		if msg.Action == "starting" || msg.Action == "stopping" || msg.Action == "restarting" {
+		if msg.Action == "starting" || msg.Action == "stopping" || msg.Action == "restarting" || msg.Action == "pausing" || msg.Action == "unpausing" {
 			cmds = append(cmds, s.updateContainersCmd())
 			stopSpinner = false
 		}
@@ -210,6 +210,8 @@ func (s *Section) handleKey(msg tea.KeyMsg) base.UpdateResult {
 		return base.UpdateResult{Cmd: s.confirmContainerToggle(), Handled: true}
 	case key.Matches(msg, keys.Keys.ContainerRestart):
 		return base.UpdateResult{Cmd: s.confirmContainerRestart(), Handled: true}
+	case key.Matches(msg, keys.Keys.ContainerPauseUnpause):
+		return base.UpdateResult{Cmd: s.confirmContainerPauseUnpause(), Handled: true}
 	}
 	return base.UpdateResult{}
 }
@@ -305,6 +307,35 @@ func (s *Section) pruneContainersCmd() tea.Cmd {
 	}
 }
 
+func (s *Section) pauseUnpauseContainerCmd() tea.Cmd {
+	ctx := s.ctx
+	svc := s.service
+	items := s.List.Items()
+	idx := s.List.Index()
+	if idx < 0 || idx >= len(items) {
+		return nil
+	}
+
+	ci, ok := items[idx].(containerItem)
+	if !ok {
+		return nil
+	}
+
+	container := ci.container
+	return func() tea.Msg {
+		var err error
+		var action string
+		if container.State == client.StatePaused {
+			action = "unpausing"
+			err = svc.Unpause(ctx, container.ID)
+		} else {
+			action = "pausing"
+			err = svc.Pause(ctx, container.ID)
+		}
+		return containerActionMsg{ID: container.ID, Action: action, Idx: idx, Error: err}
+	}
+}
+
 func (s *Section) confirmContainerPrune() tea.Cmd {
 	pruneCmd := s.pruneContainersCmd()
 	return func() tea.Msg {
@@ -378,4 +409,31 @@ func (s *Section) confirmContainerRestart() tea.Cmd {
 			OnConfirm: s.WithSpinner(restartCmd),
 		}
 	}
+}
+
+func (s *Section) confirmContainerPauseUnpause() tea.Cmd {
+	items := s.List.Items()
+	idx := s.List.Index()
+	if idx < 0 || idx >= len(items) {
+		return nil
+	}
+
+	ci, ok := items[idx].(containerItem)
+	if !ok {
+		return nil
+	}
+
+	action := "Pause"
+	if ci.container.State == client.StatePaused {
+		action = "Unpause"
+	}
+	pauseUnpauseCmd := s.pauseUnpauseContainerCmd()
+	return func() tea.Msg {
+		return message.ShowConfirmationMsg{
+			Title:     fmt.Sprintf("%s Container", action),
+			Body:      fmt.Sprintf("%s container %s?", action, helper.ShortID(ci.ID())),
+			OnConfirm: s.WithSpinner(pauseUnpauseCmd),
+		}
+	}
+
 }

--- a/internal/ui/sections/containers/section_test.go
+++ b/internal/ui/sections/containers/section_test.go
@@ -246,6 +246,18 @@ func TestContainerListPrune(t *testing.T) {
 	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
 }
 
+func TestContainerPauseUnpause(t *testing.T) {
+	tm := teatest.NewTestModel(t, newContainerSectionModel(), teatest.WithInitialTermSize(120, 40))
+	waitFor(t, tm, "nginx:latest")
+	// Toggle pause/unpause
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	waitFor(t, tm, "paused")
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	waitFor(t, tm, "running")
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
+}
+
 func TestFormatBytes(t *testing.T) {
 	tests := []struct {
 		input    uint64


### PR DESCRIPTION
Implements Pause and Unpause for container as requested in #8. Adds two new methods to the ContainerService interface, their concrete implementation, key bindings for the TUI, and updates the mock accordingly.

<img width="1843" height="1030" alt="demo" src="https://github.com/user-attachments/assets/c5a41d51-479d-4614-a2df-bd85b718e315" />



