### PR TITLE
update goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,5 +75,5 @@ homebrew_casks:
       post:
         install: |
           if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/docker-dash"]
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{bin}/docker-dash"]
           end


### PR DESCRIPTION
With the latest [release](https://github.com/GustavoCaso/docker-dash/releases/tag/v0.0.9) the post hook for homebrew failed:

```
Linking Binary 'docker-dash_v0.0.8_darwin-arm64' to '/opt/homebrew/bin/docker-dash'
Error: gustavocaso/tap/docker-dash: Failure while executing; `/usr/bin/env /usr/bin/xattr -dr com.apple.quarantine /opt/homebrew/Caskroom/docker-dash/0.0.9/docker-dash` exited with 1. Here's the output:
xattr: No such file: /opt/homebrew/Caskroom/docker-dash/0.0.9/docker-dash
```

The issue is that the binary name includes the version and the arch:
```
ls -la /opt/homebrew/bin/docker-dash
lrwxr-xr-x@ 1 gustavocaso  admin    72B Apr 16 06:30 /opt/homebrew/bin/docker-dash -> /opt/homebrew/Caskroom/docker-dash/0.0.8/docker-dash_v0.0.8_darwin-arm64
```

Attempting to fix it by using `#{bin}`