### PR TITLE
Parallelize app start

### DIFF
--- a/cmd/docker-dash/main.go
+++ b/cmd/docker-dash/main.go
@@ -88,7 +88,7 @@ func main() {
 	}
 
 	p := tea.NewProgram(
-		ui.InitialModel(ctx, Version, cfg, dockerClient),
+		ui.New(ctx, Version, cfg, dockerClient),
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(),
 	)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -83,7 +84,6 @@ type model struct {
 	spinner          spinner.Model
 	spinnerRequests  map[string]spinnerRequest
 	spinnerSequence  uint64
-	initErr          string
 	confirmation     confirmation.Model
 	pendingCmd       tea.Cmd
 	showConfirmation bool
@@ -98,31 +98,7 @@ type spinnerRequest struct {
 	Seq   uint64
 }
 
-func InitialModel(ctx context.Context, version string, cfg *config.Config, client client.Client) tea.Model {
-	containersList, containersErr := client.Containers().List(ctx)
-	imagesList, imagesErr := client.Images().List(ctx)
-	volumesList, volumesErr := client.Volumes().List(ctx)
-	networksList, networksErr := client.Networks().List(ctx)
-	composeList, composeErr := client.Compose().List(ctx)
-
-	var initErr string
-	for _, err := range []error{containersErr, imagesErr, volumesErr, networksErr, composeErr} {
-		if err != nil {
-			initErr = "Failed to load data: " + err.Error()
-			break
-		}
-	}
-
-	var refreshInterval time.Duration
-	if cfg.Refresh.Interval != "" {
-		d, err := time.ParseDuration(cfg.Refresh.Interval)
-		if err != nil {
-			initErr = "Invalid refresh interval: " + err.Error()
-		} else {
-			refreshInterval = d
-		}
-	}
-
+func New(ctx context.Context, version string, cfg *config.Config, client client.Client) tea.Model {
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
 	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
@@ -137,34 +113,40 @@ func InitialModel(ctx context.Context, version string, cfg *config.Config, clien
 		networkKeys:      keys.Keys.NetworkKeyMap(),
 		composeKeys:      keys.Keys.ComposeKeyMap(),
 		header:           header.New(version),
-		containerSection: containers.New(ctx, containersList, client.Containers()),
-		imageSection:     images.New(ctx, imagesList, client, cfg.UpdateCheck),
-		volumeSection:    volumes.New(ctx, volumesList, client.Volumes()),
-		networkSection:   networks.New(ctx, networksList, client.Networks()),
-		composeSection:   compose.New(ctx, composeList, client.Compose()),
 		statusBar:        statusbar.New(),
 		spinner:          sp,
 		spinnerRequests:  make(map[string]spinnerRequest),
-		initErr:          initErr,
 		confirmation:     confirmation.New(),
-		refreshInterval:  refreshInterval,
+		containerSection: containers.New(ctx, client.Containers()),
+		imageSection:     images.New(ctx, client, cfg.UpdateCheck),
+		volumeSection:    volumes.New(ctx, client.Volumes()),
+		networkSection:   networks.New(ctx, client.Networks()),
+		composeSection:   compose.New(ctx, client.Compose()),
 	}
 }
 
 func (m *model) Init() tea.Cmd {
-	if m.initErr != "" {
-		return func() tea.Msg {
-			return message.ShowBannerMsg{Message: m.initErr, IsError: true}
+	cmds := []tea.Cmd{}
+
+	if m.cfg.Refresh.Interval != "" {
+		d, err := time.ParseDuration(m.cfg.Refresh.Interval)
+		if err != nil {
+			errorMessage := fmt.Sprintf("Invalid refresh interval %q: %v", m.cfg.Refresh.Interval, err.Error())
+			cmds = append(cmds, func() tea.Msg {
+				return message.ShowBannerMsg{Message: errorMessage, IsError: true}
+			})
+		} else {
+			m.refreshInterval = d
 		}
 	}
 
-	cmds := []tea.Cmd{
+	cmds = append(cmds, []tea.Cmd{
 		m.imageSection.Init(),
 		m.containerSection.Init(),
 		m.volumeSection.Init(),
 		m.networkSection.Init(),
 		m.composeSection.Init(),
-	}
+	}...)
 
 	if m.refreshInterval > 0 {
 		cmds = append(cmds, tea.Tick(m.refreshInterval, func(_ time.Time) tea.Msg {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestFullOutput(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 	waitForString(t, tm, "Images")
 	tm.Send(tea.KeyMsg{
@@ -28,7 +28,7 @@ func TestFullOutput(t *testing.T) {
 }
 
 func TestExecPanel(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 
 	// Wait for initial render
@@ -57,7 +57,7 @@ func TestExecPanel(t *testing.T) {
 }
 
 func TestContainerSwitchSectionResetsPanel(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 	waitForString(t, tm, "Images")
 	// Switch to Containers view
@@ -78,7 +78,7 @@ func TestContainerSwitchSectionResetsPanel(t *testing.T) {
 }
 
 func TestSwitchingSectionResetActiveView(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 	waitForString(t, tm, "Images")
 	// Switch section and back
@@ -92,7 +92,7 @@ func TestSwitchingSectionResetActiveView(t *testing.T) {
 }
 
 func TestSwitchingSectionResetVolumesActiveView(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 	waitForString(t, tm, "Images")
 	// Navigate to Volumes view (Images -> Containers -> Volumes)
@@ -110,7 +110,7 @@ func TestSwitchingSectionResetVolumesActiveView(t *testing.T) {
 }
 
 func TestSwitchingSectionResetNetworksActiveView(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 	waitForString(t, tm, "Images")
 	// Navigate to Networks view (Images -> Containers -> Volumes -> Networks)
@@ -129,7 +129,7 @@ func TestSwitchingSectionResetNetworksActiveView(t *testing.T) {
 }
 
 func TestVolumesView(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 
 	// Wait for initial render
@@ -152,7 +152,7 @@ func TestAutoRefreshInvalidInterval(t *testing.T) {
 	cfg := &config.Config{
 		Refresh: config.RefreshConfig{Interval: "not-a-duration"},
 	}
-	m := InitialModel(context.Background(), "test", cfg, client.NewMockClient())
+	m := New(context.Background(), "test", cfg, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 
 	// Invalid interval should surface as an error banner
@@ -166,7 +166,7 @@ func TestAutoRefreshValidInterval(t *testing.T) {
 	cfg := &config.Config{
 		Refresh: config.RefreshConfig{Interval: "500ms"},
 	}
-	m := InitialModel(context.Background(), "test", cfg, client.NewMockClient())
+	m := New(context.Background(), "test", cfg, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 
 	// UI should still render normally with a valid interval configured
@@ -177,7 +177,7 @@ func TestAutoRefreshValidInterval(t *testing.T) {
 }
 
 func TestConfirmationModalAppearsOnDelete(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 
 	// Default view is Images — wait for it
@@ -200,7 +200,7 @@ func TestConfirmationModalAppearsOnDelete(t *testing.T) {
 }
 
 func TestConfirmationModalDismissedOnN(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 
 	waitForString(t, tm, "nginx")
@@ -218,7 +218,7 @@ func TestConfirmationModalDismissedOnN(t *testing.T) {
 }
 
 func TestConfirmationModalDismissedOnEsc(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 
 	waitForString(t, tm, "nginx")
@@ -236,7 +236,7 @@ func TestConfirmationModalDismissedOnEsc(t *testing.T) {
 }
 
 func TestConfirmationModalConfirmDeletesImage(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(300, 100))
 
 	waitForString(t, tm, "nginx")
@@ -254,7 +254,7 @@ func TestConfirmationModalConfirmDeletesImage(t *testing.T) {
 }
 
 func TestContextualKeyBindingsBeforeViewRender(t *testing.T) {
-	m := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient())
+	m := New(context.Background(), "test", &config.Config{}, client.NewMockClient())
 
 	// Send AddContextualKeyBindingsMsg before activeKeys is set — must not panic.
 	m.Update(message.AddContextualKeyBindingsMsg{
@@ -266,9 +266,9 @@ func TestContextualKeyBindingsBeforeViewRender(t *testing.T) {
 }
 
 func TestSpinnerOverlayFollowsShowAndCancelMessages(t *testing.T) {
-	appModel, ok := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient()).(*model)
+	appModel, ok := New(context.Background(), "test", &config.Config{}, client.NewMockClient()).(*model)
 	if !ok {
-		t.Fatal("InitialModel should return *model")
+		t.Fatal("New should return *model")
 	}
 
 	appModel.Update(tea.WindowSizeMsg{Width: 300, Height: 100})
@@ -292,9 +292,9 @@ func TestSpinnerOverlayFollowsShowAndCancelMessages(t *testing.T) {
 }
 
 func TestSpinnerOverlayHidesWhenActiveSectionHasNoSpinner(t *testing.T) {
-	appModel, ok := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient()).(*model)
+	appModel, ok := New(context.Background(), "test", &config.Config{}, client.NewMockClient()).(*model)
 	if !ok {
-		t.Fatal("InitialModel should return *model")
+		t.Fatal("New should return *model")
 	}
 
 	appModel.Update(tea.WindowSizeMsg{Width: 300, Height: 100})
@@ -320,9 +320,9 @@ func TestSpinnerOverlayHidesWhenActiveSectionHasNoSpinner(t *testing.T) {
 }
 
 func TestSpinnerOverlayIgnoresNestedActiveSpinner(t *testing.T) {
-	appModel, ok := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient()).(*model)
+	appModel, ok := New(context.Background(), "test", &config.Config{}, client.NewMockClient()).(*model)
 	if !ok {
-		t.Fatal("InitialModel should return *model")
+		t.Fatal("New should return *model")
 	}
 
 	appModel.Update(tea.WindowSizeMsg{Width: 300, Height: 100})
@@ -342,9 +342,9 @@ func TestSpinnerOverlayIgnoresNestedActiveSpinner(t *testing.T) {
 }
 
 func TestSpinnerOverlayShowsNestedSpinnerForActivePanel(t *testing.T) {
-	appModel, ok := InitialModel(context.Background(), "test", &config.Config{}, client.NewMockClient()).(*model)
+	appModel, ok := New(context.Background(), "test", &config.Config{}, client.NewMockClient()).(*model)
 	if !ok {
-		t.Fatal("InitialModel should return *model")
+		t.Fatal("New should return *model")
 	}
 
 	appModel.Update(tea.WindowSizeMsg{Width: 300, Height: 100})

--- a/internal/ui/sections/base/base.go
+++ b/internal/ui/sections/base/base.go
@@ -73,10 +73,9 @@ type UpdateResult struct {
 
 func New(
 	name sections.SectionName,
-	items []list.Item,
-	pannels []panel.Panel,
+	panels []panel.Panel,
 ) *Section {
-	l := list.New(items, list.NewDefaultDelegate(), 0, 0)
+	l := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
 	l.SetShowTitle(false)
 	l.SetShowHelp(false)
 	l.SetShowStatusBar(true)
@@ -84,17 +83,19 @@ func New(
 	return &Section{
 		name:           name,
 		List:           l,
-		panels:         pannels,
+		panels:         panels,
 		activePanelIdx: 0,
 	}
 }
 
-// Init implements the bubbletea Model Init method.  For panel sections it
-// initialises the active panel for the currently-selected item; for sections
-// without panels it is a no-op (updateActivePanel returns nil when
-// ActivePanelInitFn is not set).
+// Init implements the bubbletea Model Init method. It fires RefreshCmd to
+// load data asynchronously (with spinner).
 func (b *Section) Init() tea.Cmd {
-	return b.updateActivePanel()
+	var refreshCmd tea.Cmd
+	if b.RefreshCmd != nil {
+		refreshCmd = b.WithSpinner(b.RefreshCmd())
+	}
+	return refreshCmd
 }
 
 // SetSize sets dimensions, using a split-pane layout when panels are
@@ -177,7 +178,7 @@ func (b *Section) Update(msg tea.Msg) tea.Cmd {
 				currentPanel := b.ActivePanel()
 				var listCmd tea.Cmd
 				b.List, listCmd = b.List.Update(keyMsg)
-				return tea.Batch(listCmd, currentPanel.Close(), b.updateActivePanel())
+				return tea.Batch(listCmd, currentPanel.Close(), b.UpdateActivePanel())
 			}
 			var listCmd tea.Cmd
 			b.List, listCmd = b.List.Update(keyMsg)
@@ -217,7 +218,7 @@ func (b *Section) RemoveItemAndUpdatePanel(idx int) tea.Cmd {
 		return b.ActivePanel().Close()
 	}
 	b.List.Select(min(idx, len(b.List.Items())-1))
-	return b.updateActivePanel()
+	return b.UpdateActivePanel()
 }
 
 // RemoveItem removes the item at idx from the list and clamps the selection.
@@ -228,6 +229,24 @@ func (b *Section) RemoveItem(idx int) {
 	if len(b.List.Items()) > 0 {
 		b.List.Select(min(idx, len(b.List.Items())-1))
 	}
+}
+
+// UpdateActivePanel calls ActivePanelInitFn on the selected list item and
+// passes the result to the active panel's Init method.
+// Returns nil when no item is selected or ActivePanelInitFn is not set.
+func (b *Section) UpdateActivePanel() tea.Cmd {
+	if b.ActivePanelInitFn == nil {
+		return nil
+	}
+	selected := b.List.SelectedItem()
+	if selected == nil {
+		return nil
+	}
+	id := b.ActivePanelInitFn(selected)
+	if id == "" {
+		return nil
+	}
+	return b.ActivePanel().Init(id)
 }
 
 // handleFilterKey processes keyboard events while filter mode is active.
@@ -384,32 +403,14 @@ func (b *Section) handlePanelKeys(msg tea.KeyMsg) (bool, tea.Cmd) {
 		currentPanel := b.ActivePanel()
 		b.activePanelIdx = (b.activePanelIdx + 1) % len(b.panels)
 		log.Printf("[%s] switching panel to: %q", b.name, b.panels[b.activePanelIdx].Name())
-		return true, tea.Batch(currentPanel.Close(), b.updateActivePanel())
+		return true, tea.Batch(currentPanel.Close(), b.UpdateActivePanel())
 	case key.Matches(msg, keys.Keys.PanelPrev):
 		currentPanel := b.ActivePanel()
 		b.activePanelIdx = (b.activePanelIdx - 1 + len(b.panels)) % len(b.panels)
 		log.Printf("[%s] switching panel to: %q", b.name, b.panels[b.activePanelIdx].Name())
-		return true, tea.Batch(currentPanel.Close(), b.updateActivePanel())
+		return true, tea.Batch(currentPanel.Close(), b.UpdateActivePanel())
 	}
 	return false, nil
-}
-
-// updateActivePanel calls ActivePanelInitFn on the selected list item and
-// passes the result to the active panel's Init method.
-// Returns nil when no item is selected or ActivePanelInitFn is not set.
-func (b *Section) updateActivePanel() tea.Cmd {
-	if b.ActivePanelInitFn == nil {
-		return nil
-	}
-	selected := b.List.SelectedItem()
-	if selected == nil {
-		return nil
-	}
-	id := b.ActivePanelInitFn(selected)
-	if id == "" {
-		return nil
-	}
-	return b.ActivePanel().Init(id)
 }
 
 // renderWithPanels renders the full split-pane view: list on the left and the

--- a/internal/ui/sections/base/base_test.go
+++ b/internal/ui/sections/base/base_test.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/GustavoCaso/docker-dash/internal/ui/components/panel"
+	"github.com/GustavoCaso/docker-dash/internal/ui/sections"
 )
 
 type fakeItem struct {
@@ -55,10 +56,18 @@ func (f *fakePanel) SetSize(width, height int) {
 	f.height = height
 }
 
-func TestRemoveItemAndUpdatePanel(t *testing.T) {
-	fakePanel := &fakePanel{}
+// newSectionWithItems creates a Section.
+func newSectionWithItems(items []list.Item, panels []panel.Panel) *Section {
+	s := New(sections.SectionName("test"), panels)
+	s.List.SetItems(items)
+	return s
+}
 
-	section := New("test", []list.Item{fakeItem{name: "test"}}, []panel.Panel{fakePanel})
+func TestRemoveItemAndUpdatePanel(t *testing.T) {
+	fp := &fakePanel{}
+	items := []list.Item{fakeItem{name: "test"}}
+
+	section := newSectionWithItems(items, []panel.Panel{fp})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
@@ -68,18 +77,18 @@ func TestRemoveItemAndUpdatePanel(t *testing.T) {
 	if cmd != nil {
 		t.Error("removeItem() should return nil cmd when list is empty (Close() returns nil)")
 	}
-	if !fakePanel.closed {
+	if !fp.closed {
 		t.Error("RemoveItemAndUpdatePanel() should close the panel when there is not item left")
 	}
 }
 
 func TestRemoveItemAndUpdatePanelUpdatesSelection(t *testing.T) {
-	fakePanel := &fakePanel{}
+	fp := &fakePanel{}
 	items := []list.Item{
 		fakeItem{name: "item1"},
 		fakeItem{name: "item2"},
 	}
-	section := New("test", items, []panel.Panel{fakePanel})
+	section := newSectionWithItems(items, []panel.Panel{fp})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
@@ -104,13 +113,13 @@ func TestRemoveItemAndUpdatePanelUpdatesSelection(t *testing.T) {
 }
 
 func TestRemoveItemAndUpdatePanelMiddleItemClampsToLastWhenAtEnd(t *testing.T) {
-	fakePanel := &fakePanel{}
+	fp := &fakePanel{}
 	items := []list.Item{
 		fakeItem{name: "item1"},
 		fakeItem{name: "item2"},
 		fakeItem{name: "item3"},
 	}
-	section := New("test", items, []panel.Panel{fakePanel})
+	section := newSectionWithItems(items, []panel.Panel{fp})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
@@ -134,13 +143,13 @@ func TestRemoveItemAndUpdatePanelMiddleItemClampsToLastWhenAtEnd(t *testing.T) {
 }
 
 func TestRemoveItemUpdatesSelection(t *testing.T) {
-	fakePanel := &fakePanel{}
+	fp := &fakePanel{}
 	items := []list.Item{
 		fakeItem{name: "item1"},
 		fakeItem{name: "item2"},
 		fakeItem{name: "item3"},
 	}
-	section := New("test", items, []panel.Panel{fakePanel})
+	section := newSectionWithItems(items, []panel.Panel{fp})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
@@ -161,19 +170,19 @@ func TestRemoveItemUpdatesSelection(t *testing.T) {
 }
 
 func TestRemoveItem_LastItemClampsSelection(t *testing.T) {
-	fakePanel := &fakePanel{}
+	fp := &fakePanel{}
 	items := []list.Item{
 		fakeItem{name: "item1"},
 		fakeItem{name: "item2"},
 		fakeItem{name: "item3"},
 	}
-	section := New("test", items, []panel.Panel{fakePanel})
+	section := newSectionWithItems(items, []panel.Panel{fp})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
 	}
 
-	// Select and delete items until one remains
+	// Delete items until one remains
 	for len(section.List.Items()) > 1 {
 		section.RemoveItem(len(section.List.Items()) - 1)
 	}
@@ -187,7 +196,7 @@ func TestRemoveItem_LastItemClampsSelection(t *testing.T) {
 }
 
 func TestResetClearsFilterFlag(t *testing.T) {
-	section := New("test", []list.Item{}, []panel.Panel{})
+	section := New(sections.SectionName("test"), []panel.Panel{})
 
 	section.isFilter = true
 
@@ -199,12 +208,12 @@ func TestResetClearsFilterFlag(t *testing.T) {
 }
 
 func TestPanelClosedOnDownNavigation(t *testing.T) {
-	fakePanel := &fakePanel{}
+	fp := &fakePanel{}
 	items := []list.Item{
 		fakeItem{name: "item1"},
 		fakeItem{name: "item2"},
 	}
-	section := New("test", items, []panel.Panel{fakePanel})
+	section := newSectionWithItems(items, []panel.Panel{fp})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
@@ -213,36 +222,36 @@ func TestPanelClosedOnDownNavigation(t *testing.T) {
 	// Navigate down to next container - this should close the current panel
 	section.Update(tea.KeyMsg{Type: tea.KeyDown})
 
-	// Verify the fake panel was closed and receieve the new id
-	if !fakePanel.closed {
+	// Verify the fake panel was closed and receive the new id
+	if !fp.closed {
 		t.Error("Navigation should close fake panel")
 	}
-	if !slices.Contains(fakePanel.ids, "item2") {
-		t.Errorf("fake panel should receive the update for the new active item, got %q", fakePanel.ids)
+	if !slices.Contains(fp.ids, "item2") {
+		t.Errorf("fake panel should receive the update for the new active item, got %q", fp.ids)
 	}
 }
 
 func TestPanelClosedOnUpNavigation(t *testing.T) {
-	fakePanel := &fakePanel{}
+	fp := &fakePanel{}
 	items := []list.Item{
 		fakeItem{name: "item1"},
 		fakeItem{name: "item2"},
 	}
-	section := New("test", items, []panel.Panel{fakePanel})
+	section := newSectionWithItems(items, []panel.Panel{fp})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
 	}
 
-	// Navigate down to next container - this should close the current panel
+	// Navigate up — selection wraps/stays, panel gets closed and re-inited
 	section.Update(tea.KeyMsg{Type: tea.KeyUp})
 
-	// Verify the fake panel was closed and receieve the new id
-	if !fakePanel.closed {
+	// Verify the fake panel was closed and receive the new id
+	if !fp.closed {
 		t.Error("Navigation should close fake panel")
 	}
-	if !slices.Contains(fakePanel.ids, "item1") {
-		t.Errorf("fake panel should receive the update for the new active item, got %q", fakePanel.ids)
+	if !slices.Contains(fp.ids, "item1") {
+		t.Errorf("fake panel should receive the update for the new active item, got %q", fp.ids)
 	}
 }
 
@@ -250,7 +259,7 @@ func TestPanelNextSwitchesActivePanel(t *testing.T) {
 	panelA := &fakePanel{name: "panelA"}
 	panelB := &fakePanel{name: "panelB"}
 	items := []list.Item{fakeItem{name: "item1"}}
-	section := New("test", items, []panel.Panel{panelA, panelB})
+	section := newSectionWithItems(items, []panel.Panel{panelA, panelB})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
@@ -279,7 +288,7 @@ func TestPanelNextWrapsAround(t *testing.T) {
 	panelA := &fakePanel{name: "panelA"}
 	panelB := &fakePanel{name: "panelB"}
 	items := []list.Item{fakeItem{name: "item1"}}
-	section := New("test", items, []panel.Panel{panelA, panelB})
+	section := newSectionWithItems(items, []panel.Panel{panelA, panelB})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
@@ -303,7 +312,7 @@ func TestPanelPrevSwitchesActivePanel(t *testing.T) {
 	panelA := &fakePanel{name: "panelA"}
 	panelB := &fakePanel{name: "panelB"}
 	items := []list.Item{fakeItem{name: "item1"}}
-	section := New("test", items, []panel.Panel{panelA, panelB})
+	section := newSectionWithItems(items, []panel.Panel{panelA, panelB})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name
@@ -330,7 +339,7 @@ func TestPanelPrevWrapsAround(t *testing.T) {
 	panelA := &fakePanel{name: "panelA"}
 	panelB := &fakePanel{name: "panelB"}
 	items := []list.Item{fakeItem{name: "item1"}}
-	section := New("test", items, []panel.Panel{panelA, panelB})
+	section := newSectionWithItems(items, []panel.Panel{panelA, panelB})
 	section.ActivePanelInitFn = func(item list.Item) string {
 		i := item.(fakeItem)
 		return i.name

--- a/internal/ui/sections/compose/section.go
+++ b/internal/ui/sections/compose/section.go
@@ -64,16 +64,11 @@ type Section struct {
 }
 
 // New creates a new Compose section.
-func New(ctx context.Context, projects []client.ComposeProject, svc client.ComposeProjectService) *Section {
-	items := make([]list.Item, len(projects))
-	for i, p := range projects {
-		items[i] = composeItem{project: p}
-	}
-
+func New(ctx context.Context, svc client.ComposeProjectService) *Section {
 	s := &Section{
 		ctx:            ctx,
 		composeService: svc,
-		Section:        base.New(sections.ComposeSection, items, []panel.Panel{newDetailsPanel()}),
+		Section:        base.New(sections.ComposeSection, []panel.Panel{newDetailsPanel()}),
 	}
 
 	s.LoadingText = "Loading..."
@@ -108,7 +103,7 @@ func (s *Section) handleMsg(msg tea.Msg) base.UpdateResult {
 			}
 		}
 		return base.UpdateResult{
-			Cmd:         tea.Batch(s.List.SetItems(msg.items), s.Section.Init()),
+			Cmd:         tea.Batch(s.List.SetItems(msg.items), s.UpdateActivePanel()),
 			Handled:     true,
 			StopSpinner: true,
 		}

--- a/internal/ui/sections/compose/section_test.go
+++ b/internal/ui/sections/compose/section_test.go
@@ -20,9 +20,10 @@ type composeSectionModel struct {
 
 func newModel() composeSectionModel {
 	c := client.NewMockClient()
-	projects, _ := c.Compose().List(context.Background())
-	section := New(context.Background(), projects, c.Compose())
+	section := New(context.Background(), c.Compose())
 	section.SetSize(120, 40)
+	// Load data synchronously so tests that call View/Update directly work without teatest.
+	section.Update(section.RefreshCmd()())
 	return composeSectionModel{section: section}
 }
 

--- a/internal/ui/sections/containers/section.go
+++ b/internal/ui/sections/containers/section.go
@@ -66,16 +66,11 @@ type Section struct {
 }
 
 // New creates a new container list.
-func New(ctx context.Context, containers []client.Container, svc client.ContainerService) *Section {
-	items := make([]list.Item, len(containers))
-	for i, c := range containers {
-		items[i] = containerItem{container: c}
-	}
-
+func New(ctx context.Context, svc client.ContainerService) *Section {
 	cl := &Section{
 		ctx:     ctx,
 		service: svc,
-		Section: base.New(sections.ContainersSection, items, []panel.Panel{
+		Section: base.New(sections.ContainersSection, []panel.Panel{
 			NewDetailsPanel(ctx, svc),
 			NewLogsPanel(ctx, svc),
 			NewStatsPanel(ctx, svc),
@@ -116,7 +111,11 @@ func (s *Section) handleMsg(msg tea.Msg) base.UpdateResult {
 				StopSpinner: true,
 			}
 		}
-		return base.UpdateResult{Cmd: s.List.SetItems(msg.items), Handled: true, StopSpinner: true}
+		return base.UpdateResult{
+			Cmd:         tea.Batch(s.List.SetItems(msg.items), s.UpdateActivePanel()),
+			Handled:     true,
+			StopSpinner: true,
+		}
 	case containersPrunedMsg:
 		log.Printf(
 			"[containers] containersPrunedMsg: deleted=%d spaceReclaimed=%d",

--- a/internal/ui/sections/containers/section_test.go
+++ b/internal/ui/sections/containers/section_test.go
@@ -20,8 +20,7 @@ type containerSectionModel struct {
 
 func newContainerSectionModel() containerSectionModel {
 	client := client.NewMockClient()
-	containers, _ := client.Containers().List(context.Background())
-	section := New(context.Background(), containers, client.Containers())
+	section := New(context.Background(), client.Containers())
 	section.SetSize(120, 40)
 	return containerSectionModel{section: section}
 }
@@ -186,8 +185,7 @@ func TestContainerListRefresh(t *testing.T) {
 
 func TestContainerListExecMouseScroll(t *testing.T) {
 	dockerClient := client.NewMockClient()
-	containers, _ := dockerClient.Containers().List(context.Background())
-	section := New(context.Background(), containers, dockerClient.Containers())
+	section := New(context.Background(), dockerClient.Containers())
 	section.SetSize(120, 40)
 
 	// Navigate to stats panel (details=0, logs=1, stats=2, files=3 exec=4)
@@ -214,8 +212,7 @@ func TestContainerListExecMouseScroll(t *testing.T) {
 
 func TestActivePanelClosedOnLogsSessionClose(t *testing.T) {
 	dockerClient := client.NewMockClient()
-	containers, _ := dockerClient.Containers().List(context.Background())
-	section := New(context.Background(), containers, dockerClient.Containers())
+	section := New(context.Background(), dockerClient.Containers())
 	section.SetSize(120, 40)
 
 	// Navigate to stats panel (details=0, logs=1, stats=2, files=3 exec=4)

--- a/internal/ui/sections/images/section.go
+++ b/internal/ui/sections/images/section.go
@@ -90,22 +90,16 @@ type Section struct {
 }
 
 // New creates a new image section.
-func New(ctx context.Context, images []client.Image, client client.Client, cfg config.UpdateCheckConfig) *Section {
-	items := make([]list.Item, len(images))
-	for i, img := range images {
-		items[i] = imageItem{image: img}
-	}
-
+func New(ctx context.Context, client client.Client, cfg config.UpdateCheckConfig) *Section {
 	il := &Section{
 		ctx:              ctx,
 		cfg:              cfg,
 		imageService:     client.Images(),
 		containerService: client.Containers(),
-		currentImages:    images,
+		currentImages:    nil,
 		imageUpdates:     make(map[string]bool),
 		Section: base.New(
 			sections.ImagesSection,
-			items,
 			[]panel.Panel{NewLayersPanel(ctx, client.Images())},
 		),
 	}
@@ -210,7 +204,11 @@ func (s *Section) handleMsg(msg tea.Msg) base.UpdateResult {
 
 			items[idx] = imageItem{image: img, hasUpdate: update}
 		}
-		return base.UpdateResult{Cmd: s.List.SetItems(items), Handled: true, StopSpinner: true}
+		return base.UpdateResult{
+			Cmd:         tea.Batch(s.List.SetItems(items), s.UpdateActivePanel()),
+			Handled:     true,
+			StopSpinner: true,
+		}
 	case imagesPrunedMsg:
 		log.Printf(
 			"[images] imagesPrunedMsg: deleted=%d spaceReclaimed=%d",

--- a/internal/ui/sections/images/section_test.go
+++ b/internal/ui/sections/images/section_test.go
@@ -31,8 +31,7 @@ type imageSectionModel struct {
 
 func newModel() imageSectionModel {
 	client := client.NewMockClient()
-	images, _ := client.Images().List(context.Background())
-	section := New(context.Background(), images, client, config.UpdateCheckConfig{})
+	section := New(context.Background(), client, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
 	return imageSectionModel{section: section}
 }
@@ -69,8 +68,7 @@ func TestInitShowsBannerForInvalidUpdateCheckInterval(t *testing.T) {
 	t.Parallel()
 
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{
+	section := New(context.Background(), c, config.UpdateCheckConfig{
 		Enabled:  true,
 		Interval: "not-a-duration",
 	})
@@ -102,8 +100,7 @@ func TestInitShowsBannerForNonPositiveUpdateCheckInterval(t *testing.T) {
 	t.Parallel()
 
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{
+	section := New(context.Background(), c, config.UpdateCheckConfig{
 		Enabled:  true,
 		Interval: "0s",
 	})
@@ -181,9 +178,9 @@ func TestImageListRefresh(t *testing.T) {
 
 func TestRunContainerKeyShowsForm(t *testing.T) {
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{})
+	section := New(context.Background(), c, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
+	section.Update(section.RefreshCmd()())
 
 	cmd := section.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
 	if cmd == nil {
@@ -214,8 +211,7 @@ func TestImageListPrune(t *testing.T) {
 
 func TestPullImageKeyShowsForm(t *testing.T) {
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{})
+	section := New(context.Background(), c, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
 
 	cmd := section.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("+")})
@@ -235,8 +231,7 @@ func TestPullImageKeyShowsForm(t *testing.T) {
 
 func TestPullImageCmdSuccess(t *testing.T) {
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{})
+	section := New(context.Background(), c, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
 
 	cmd := section.pullImageCmd("nginx:latest", "")
@@ -263,8 +258,7 @@ func TestPullImageCmdError(t *testing.T) {
 		ImageService: mc.Images(),
 		pullErr:      errors.New("pull failed"),
 	}
-	images, _ := mc.Images().List(context.Background())
-	section := New(context.Background(), images, mc, config.UpdateCheckConfig{})
+	section := New(context.Background(), mc, config.UpdateCheckConfig{})
 	section.imageService = errImageSvc
 	section.SetSize(120, 40)
 
@@ -282,8 +276,7 @@ func TestPullImageCmdError(t *testing.T) {
 
 func TestPullImageMsgSuccess_ShowsBanner(t *testing.T) {
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{})
+	section := New(context.Background(), c, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
 
 	cmd := section.Update(imagePullMsg{image: "nginx:latest", err: nil})
@@ -312,8 +305,7 @@ func TestPullImageMsgSuccess_ShowsBanner(t *testing.T) {
 
 func TestPullImageMsgError_ShowsErrorBanner(t *testing.T) {
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{})
+	section := New(context.Background(), c, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
 
 	pullErr := errors.New("image not found")
@@ -443,13 +435,17 @@ func TestImageItemDescriptionShowsUpdateIcon(t *testing.T) {
 
 func TestImageUpdatesMsg_UpdatesListItems(t *testing.T) {
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{})
+	section := New(context.Background(), c, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
+
+	// Load images by running the RefreshCmd synchronously
+	cmd := section.RefreshCmd()
+	msg := cmd()
+	section.Update(msg)
 
 	// Find the nginx image ID (mock has nginx:latest first)
 	var nginxID string
-	for _, img := range images {
+	for _, img := range section.currentImages {
 		if img.Repo == "nginx" && img.Tag == "latest" {
 			nginxID = img.ID
 			break
@@ -484,9 +480,9 @@ func TestImageUpdatesMsg_UpdatesListItems(t *testing.T) {
 
 func TestPullUpdateCmd_NoUpdateShowsBanner(t *testing.T) {
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{})
+	section := New(context.Background(), c, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
+	section.Update(section.RefreshCmd()())
 
 	// Default: no imageUpdatesMsg sent, so hasUpdate=false for all items.
 	cmd := section.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
@@ -508,12 +504,15 @@ func TestPullUpdateCmd_NoUpdateShowsBanner(t *testing.T) {
 
 func TestPullUpdateCmd_WithUpdate_FiresPull(t *testing.T) {
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{})
+	section := New(context.Background(), c, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
 
+	// Load images synchronously first
+	loadCmd := section.RefreshCmd()
+	section.Update(loadCmd())
+
 	// Mark first image as having an update.
-	section.Update(imageUpdatesMsg{updates: map[string]bool{images[0].ID: true}})
+	section.Update(imageUpdatesMsg{updates: map[string]bool{section.currentImages[0].ID: true}})
 
 	cmd := section.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
 	if cmd == nil {
@@ -534,8 +533,7 @@ func TestPullUpdateCmd_WithUpdate_FiresPull(t *testing.T) {
 
 func TestPanelClosedOnUpNavigation(t *testing.T) {
 	c := client.NewMockClient()
-	images, _ := c.Images().List(context.Background())
-	section := New(context.Background(), images, c, config.UpdateCheckConfig{})
+	section := New(context.Background(), c, config.UpdateCheckConfig{})
 	section.SetSize(120, 40)
 
 	// Navigate to second image

--- a/internal/ui/sections/networks/section.go
+++ b/internal/ui/sections/networks/section.go
@@ -67,16 +67,11 @@ type Section struct {
 }
 
 // New creates a new network section.
-func New(ctx context.Context, networks []client.Network, svc client.NetworkService) *Section {
-	items := make([]list.Item, len(networks))
-	for i, n := range networks {
-		items[i] = networkItem{network: n}
-	}
-
+func New(ctx context.Context, svc client.NetworkService) *Section {
 	s := &Section{
 		ctx:            ctx,
 		networkService: svc,
-		Section:        base.New(sections.NetworksSection, items, []panel.Panel{newDetailsPanel()}),
+		Section:        base.New(sections.NetworksSection, []panel.Panel{newDetailsPanel()}),
 	}
 
 	s.LoadingText = "Loading..."
@@ -111,7 +106,11 @@ func (s *Section) handleMsg(msg tea.Msg) base.UpdateResult {
 				StopSpinner: true,
 			}
 		}
-		return base.UpdateResult{Cmd: s.List.SetItems(msg.items), Handled: true, StopSpinner: true}
+		return base.UpdateResult{
+			Cmd:         tea.Batch(s.List.SetItems(msg.items), s.UpdateActivePanel()),
+			Handled:     true,
+			StopSpinner: true,
+		}
 	case networksPrunedMsg:
 		log.Printf(
 			"[networks] networksPrunedMsg: deleted=%d spaceReclaimed=%d",

--- a/internal/ui/sections/networks/section_test.go
+++ b/internal/ui/sections/networks/section_test.go
@@ -19,8 +19,7 @@ type networkSectionModel struct {
 
 func newModel() networkSectionModel {
 	c := client.NewMockClient()
-	networks, _ := c.Networks().List(context.Background())
-	section := New(context.Background(), networks, c.Networks())
+	section := New(context.Background(), c.Networks())
 	section.SetSize(120, 40)
 	return networkSectionModel{section: section}
 }

--- a/internal/ui/sections/volumes/section.go
+++ b/internal/ui/sections/volumes/section.go
@@ -67,16 +67,11 @@ type Section struct {
 }
 
 // New creates a new volume list.
-func New(ctx context.Context, volumes []client.Volume, svc client.VolumeService) *Section {
-	items := make([]list.Item, len(volumes))
-	for i, v := range volumes {
-		items[i] = volumeItem{volume: v}
-	}
-
+func New(ctx context.Context, svc client.VolumeService) *Section {
 	s := &Section{
 		ctx:           ctx,
 		volumeService: svc,
-		Section:       base.New(sections.VolumesSection, items, []panel.Panel{}),
+		Section:       base.New(sections.VolumesSection, []panel.Panel{}),
 	}
 
 	s.LoadingText = "Loading..."
@@ -104,7 +99,11 @@ func (s *Section) handleMsg(msg tea.Msg) base.UpdateResult {
 				StopSpinner: true,
 			}
 		}
-		return base.UpdateResult{Cmd: s.List.SetItems(msg.items), Handled: true, StopSpinner: true}
+		return base.UpdateResult{
+			Cmd:         tea.Batch(s.List.SetItems(msg.items), s.UpdateActivePanel()),
+			Handled:     true,
+			StopSpinner: true,
+		}
 	case volumesPrunedMsg:
 		log.Printf("[volumes] volumesPrunedMsg: deleted=%d spaceReclaimed=%d",
 			msg.report.ItemsDeleted, msg.report.SpaceReclaimed)

--- a/internal/ui/sections/volumes/section_test.go
+++ b/internal/ui/sections/volumes/section_test.go
@@ -19,8 +19,7 @@ type volumeSectionModel struct {
 
 func newModel() volumeSectionModel {
 	c := client.NewMockClient()
-	volumes, _ := c.Volumes().List(context.Background())
-	section := New(context.Background(), volumes, c.Volumes())
+	section := New(context.Background(), c.Volumes())
 	section.SetSize(120, 40)
 	return volumeSectionModel{section: section}
 }


### PR DESCRIPTION
By moving to each section, the Init() function
the responsibility of fetching the items asynchronously

This frees the `ui.New` from doing any I/O 

This is a more idiomatic way of writing bubble tea apps, allowing faster rendering when initializing docker-dash