### PR TITLE
use errGroup to parallelize List commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/docker/go-connections v0.6.0
 	github.com/moby/docker-image-spec v1.3.1
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -195,7 +196,6 @@ require (
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -65,7 +65,7 @@ type RunOptions struct {
 type ContainerService interface {
 	List(ctx context.Context) ([]Container, error)
 	Run(ctx context.Context, image Image, opts RunOptions) (string, error)
-	Get(ctx context.Context, id string) (*Container, error)
+	Get(ctx context.Context, id string) (Container, error)
 	Start(ctx context.Context, id string) error
 	Stop(ctx context.Context, id string) error
 	Restart(ctx context.Context, id string) error

--- a/internal/client/docker.go
+++ b/internal/client/docker.go
@@ -14,6 +14,10 @@ import (
 	"github.com/GustavoCaso/docker-dash/internal/config"
 )
 
+// parallelInspectLimit caps concurrent inspect calls in List operations.
+// Prevents overwhelming SSH transports (MaxStartups / connection reset).
+const parallelInspectLimit = 8
+
 // dockerClient connects to a local or remote Docker daemon.
 type dockerClient struct {
 	cli        *client.Client

--- a/internal/client/docker_container_service.go
+++ b/internal/client/docker_container_service.go
@@ -8,13 +8,16 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
+	"golang.org/x/sync/errgroup"
 )
 
 // Local Container Service.
@@ -23,70 +26,51 @@ type containerService struct {
 }
 
 func (s *containerService) List(ctx context.Context) ([]Container, error) {
-	log.Printf("[docker] ContainerList: all=true")
-	containers, listErr := s.cli.ContainerList(ctx, container.ListOptions{All: true})
-	if listErr != nil {
-		return nil, listErr
+	log.Printf("[docker] ContainerList")
+	du, err := s.cli.DiskUsage(ctx, dockertypes.DiskUsageOptions{
+		Types: []dockertypes.DiskUsageObject{dockertypes.ContainerObject},
+	})
+
+	if err != nil {
+		return nil, err
 	}
+
+	containers := du.Containers
 
 	result := make([]Container, len(containers))
+	resultMap := sync.Map{}
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(parallelInspectLimit)
+
 	for i, c := range containers {
-		name := ""
-		if len(c.Names) > 0 {
-			name = strings.TrimPrefix(c.Names[0], "/")
-		}
+		idx := i
 
-		state := StateStopped
-		switch c.State {
-		case "running":
-			state = StateRunning
-		case "paused":
-			state = StatePaused
-		case "restarting":
-			state = StateRestarting
-		}
+		group.Go(func() error {
+			container, containerErr := s.Get(groupCtx, c.ID)
 
-		ports := make([]PortMapping, 0)
-		for _, p := range c.Ports {
-			if p.PublicPort > 0 {
-				ports = append(ports, PortMapping{
-					HostPort:      p.PublicPort,
-					ContainerPort: p.PrivatePort,
-					Protocol:      p.Type,
-				})
+			if containerErr != nil {
+				return containerErr
 			}
-		}
 
-		mounts := make([]Mount, len(c.Mounts))
-		for j, m := range c.Mounts {
-			mounts[j] = Mount{
-				Type:        string(m.Type),
-				Source:      m.Source,
-				Destination: m.Destination,
-			}
-		}
+			resultMap.Store(idx, container)
 
-		ci, err := s.cli.ContainerInspect(ctx, c.ID)
-		if err != nil {
-			return nil, err
-		}
-
-		health := buildContainerHealth(ci.State.Health)
-
-		result[i] = Container{
-			ID:      c.ID,
-			Name:    name,
-			Image:   c.Image,
-			Status:  c.Status,
-			State:   state,
-			Health:  health,
-			Created: timeFromUnix(c.Created),
-			Ports:   ports,
-			Mounts:  mounts,
-		}
+			return nil
+		})
 	}
 
-	log.Printf("[docker] ContainerList: returned count=%d err=%v", len(result), listErr)
+	groupErr := group.Wait()
+	if groupErr != nil {
+		return nil, groupErr
+	}
+
+	resultMap.Range(func(key, value any) bool {
+		idx, _ := key.(int)
+		c, _ := value.(Container)
+		result[idx] = c
+		return true
+	})
+
+	log.Printf("[docker] ContainerList: returned count=%d err=%v", len(result), err)
 	return result, nil
 }
 
@@ -172,11 +156,11 @@ func (s *containerService) Run(ctx context.Context, img Image, opts RunOptions) 
 	return containerResponse.ID, nil
 }
 
-func (s *containerService) Get(ctx context.Context, id string) (*Container, error) {
+func (s *containerService) Get(ctx context.Context, id string) (Container, error) {
 	log.Printf("[docker] ContainerInspect: id=%q", id)
 	c, err := s.cli.ContainerInspect(ctx, id)
 	if err != nil {
-		return nil, err
+		return Container{}, err
 	}
 
 	state := StateStopped
@@ -192,7 +176,7 @@ func (s *containerService) Get(ctx context.Context, id string) (*Container, erro
 	var created time.Time
 	created, err = time.Parse(time.RFC3339Nano, c.Created)
 	if err != nil {
-		return nil, fmt.Errorf("parsing container created time: %w", err)
+		return Container{}, fmt.Errorf("parsing container created time: %w", err)
 	}
 
 	ports := make([]PortMapping, 0)
@@ -241,7 +225,7 @@ func (s *containerService) Get(ctx context.Context, id string) (*Container, erro
 	}
 
 	log.Printf("[docker] ContainerInspect: done")
-	return &Container{
+	return Container{
 		ID:      c.ID,
 		Name:    strings.TrimPrefix(c.Name, "/"),
 		Image:   c.Config.Image,

--- a/internal/client/docker_image_service.go
+++ b/internal/client/docker_image_service.go
@@ -6,11 +6,14 @@ import (
 	"log"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
+	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
+	"golang.org/x/sync/errgroup"
 )
 
 // Local Image Service.
@@ -19,22 +22,46 @@ type imageService struct {
 }
 
 func (s *imageService) List(ctx context.Context) ([]Image, error) {
-	log.Printf("[docker] ImageList: all=true")
-	images, err := s.cli.ImageList(ctx, image.ListOptions{All: true})
+	log.Printf("[docker] ImageList")
+	du, err := s.cli.DiskUsage(ctx, dockertypes.DiskUsageOptions{
+		Types: []dockertypes.DiskUsageObject{dockertypes.ImageObject},
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]Image, len(images))
-	for i, img := range images {
-		imageData, imageErr := s.get(ctx, img.ID)
-		if imageErr != nil {
-			return []Image{}, imageErr
-		}
+	images := du.Images
 
-		imageData.Containers = img.Containers
-		result[i] = imageData
+	result := make([]Image, len(images))
+	resultMap := sync.Map{}
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(parallelInspectLimit)
+
+	for i, img := range images {
+		idx := i
+		group.Go(func() error {
+			imageData, imageErr := s.get(groupCtx, img.ID)
+			if imageErr != nil {
+				return imageErr
+			}
+
+			imageData.Containers = img.Containers
+			resultMap.Store(idx, imageData)
+			return nil
+		})
 	}
+
+	groupErr := group.Wait()
+	if groupErr != nil {
+		return []Image{}, groupErr
+	}
+
+	resultMap.Range(func(key, value any) bool {
+		idx, _ := key.(int)
+		img, _ := value.(Image)
+		result[idx] = img
+		return true
+	})
 
 	log.Printf("[docker] ImageList: returned count=%d", len(result))
 	return result, nil

--- a/internal/client/docker_network_service.go
+++ b/internal/client/docker_network_service.go
@@ -30,23 +30,15 @@ func (s *networkService) List(ctx context.Context) ([]Network, error) {
 
 	for i, n := range networks {
 		idx := i
-		networkID := n.ID
-		networkName := n.Name
-		networkDriver := n.Driver
-		networkScope := n.Scope
-		networkInternal := n.Internal
-		networkCreated := n.Created
-		ipamConfig := n.IPAM
-
 		group.Go(func() error {
-			inspectResponse, inspectErr := s.cli.NetworkInspect(groupCtx, networkID, network.InspectOptions{})
+			inspectResponse, inspectErr := s.cli.NetworkInspect(groupCtx, n.ID, network.InspectOptions{})
 			if inspectErr != nil {
 				return inspectErr
 			}
 
 			subnet := ""
 			gateway := ""
-			if len(ipamConfig.Config) > 0 {
+			if len(inspectResponse.IPAM.Config) > 0 {
 				subnet = inspectResponse.IPAM.Config[0].Subnet
 				gateway = inspectResponse.IPAM.Config[0].Gateway
 			}
@@ -60,12 +52,12 @@ func (s *networkService) List(ctx context.Context) ([]Network, error) {
 				})
 			}
 			resultMap.Store(idx, Network{
-				ID:                  networkID,
-				Name:                networkName,
-				Driver:              networkDriver,
-				Scope:               networkScope,
-				Internal:            networkInternal,
-				Created:             networkCreated,
+				ID:                  n.ID,
+				Name:                n.Name,
+				Driver:              n.Driver,
+				Scope:               n.Scope,
+				Internal:            n.Internal,
+				Created:             n.Created,
 				ConnectedContainers: connected,
 				IPAM:                NetworkIPAM{Subnet: subnet, Gateway: gateway},
 			})

--- a/internal/client/docker_network_service.go
+++ b/internal/client/docker_network_service.go
@@ -3,10 +3,12 @@ package client
 import (
 	"context"
 	"log"
+	"sync"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"golang.org/x/sync/errgroup"
 )
 
 // Local Network Service.
@@ -22,39 +24,67 @@ func (s *networkService) List(ctx context.Context) ([]Network, error) {
 	}
 
 	result := make([]Network, len(networks))
+	resultMap := sync.Map{}
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(parallelInspectLimit)
+
 	for i, n := range networks {
-		inspectResponse, inspectErr := s.cli.NetworkInspect(ctx, n.ID, network.InspectOptions{})
+		idx := i
+		networkID := n.ID
+		networkName := n.Name
+		networkDriver := n.Driver
+		networkScope := n.Scope
+		networkInternal := n.Internal
+		networkCreated := n.Created
+		ipamConfig := n.IPAM
 
-		if inspectErr != nil {
-			return nil, inspectErr
-		}
+		group.Go(func() error {
+			inspectResponse, inspectErr := s.cli.NetworkInspect(groupCtx, networkID, network.InspectOptions{})
+			if inspectErr != nil {
+				return inspectErr
+			}
 
-		subnet := ""
-		gateway := ""
-		if len(n.IPAM.Config) > 0 {
-			subnet = inspectResponse.IPAM.Config[0].Subnet
-			gateway = inspectResponse.IPAM.Config[0].Gateway
-		}
-		connected := make([]NetworkContainer, 0, len(inspectResponse.Containers))
-		for _, c := range inspectResponse.Containers {
-			connected = append(connected, NetworkContainer{
-				Name:        c.Name,
-				IPv4Address: c.IPv4Address,
-				IPv6Address: c.IPv6Address,
-				MacAddress:  c.MacAddress,
+			subnet := ""
+			gateway := ""
+			if len(ipamConfig.Config) > 0 {
+				subnet = inspectResponse.IPAM.Config[0].Subnet
+				gateway = inspectResponse.IPAM.Config[0].Gateway
+			}
+			connected := make([]NetworkContainer, 0, len(inspectResponse.Containers))
+			for _, c := range inspectResponse.Containers {
+				connected = append(connected, NetworkContainer{
+					Name:        c.Name,
+					IPv4Address: c.IPv4Address,
+					IPv6Address: c.IPv6Address,
+					MacAddress:  c.MacAddress,
+				})
+			}
+			resultMap.Store(idx, Network{
+				ID:                  networkID,
+				Name:                networkName,
+				Driver:              networkDriver,
+				Scope:               networkScope,
+				Internal:            networkInternal,
+				Created:             networkCreated,
+				ConnectedContainers: connected,
+				IPAM:                NetworkIPAM{Subnet: subnet, Gateway: gateway},
 			})
-		}
-		result[i] = Network{
-			ID:                  n.ID,
-			Name:                n.Name,
-			Driver:              n.Driver,
-			Scope:               n.Scope,
-			Internal:            n.Internal,
-			Created:             n.Created,
-			ConnectedContainers: connected,
-			IPAM:                NetworkIPAM{Subnet: subnet, Gateway: gateway},
-		}
+			return nil
+		})
 	}
+
+	groupErr := group.Wait()
+	if groupErr != nil {
+		return nil, groupErr
+	}
+
+	resultMap.Range(func(key, value any) bool {
+		idx, _ := key.(int)
+		net, _ := value.(Network)
+		result[idx] = net
+		return true
+	})
+
 	log.Printf("[docker] NetworkList: returned count=%d", len(result))
 	return result, nil
 }

--- a/internal/client/docker_volume_service.go
+++ b/internal/client/docker_volume_service.go
@@ -15,7 +15,7 @@ type volumeService struct {
 }
 
 func (s *volumeService) List(ctx context.Context) ([]Volume, error) {
-	log.Printf("[docker] DiskUsage (volumes)")
+	log.Printf("[docker] VolumeList")
 	du, err := s.cli.DiskUsage(ctx, dockertypes.DiskUsageOptions{
 		Types: []dockertypes.DiskUsageObject{dockertypes.VolumeObject},
 	})

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -250,13 +250,13 @@ func (s *mockContainerService) Run(_ context.Context, _ Image, _ RunOptions) (st
 	return "", nil
 }
 
-func (s *mockContainerService) Get(ctx context.Context, id string) (*Container, error) {
+func (s *mockContainerService) Get(ctx context.Context, id string) (Container, error) {
 	for _, c := range s.containers {
 		if c.ID == id || c.Name == id {
-			return &c, nil
+			return c, nil
 		}
 	}
-	return nil, fmt.Errorf("container not found: %s", id)
+	return Container{}, fmt.Errorf("container not found: %s", id)
 }
 
 func (s *mockContainerService) Start(ctx context.Context, id string) error {

--- a/internal/ui/sections/containers/details_panel.go
+++ b/internal/ui/sections/containers/details_panel.go
@@ -87,7 +87,7 @@ func (d *detailsPanel) fetchCmd(containerID string) tea.Cmd {
 	}
 }
 
-func formatDetails(c *client.Container) string {
+func formatDetails(c client.Container) string {
 	var b strings.Builder
 
 	// Header

--- a/internal/ui/sections/containers/section.go
+++ b/internal/ui/sections/containers/section.go
@@ -85,7 +85,7 @@ func New(ctx context.Context, svc client.ContainerService) *Section {
 		}),
 	}
 
-	cl.LoadingText = "Refreshing..."
+	cl.LoadingText = "Loading..."
 	cl.ActivePanelInitFn = func(item list.Item) string {
 		ci, ok := item.(containerItem)
 		if !ok {

--- a/internal/ui/sections/images/section.go
+++ b/internal/ui/sections/images/section.go
@@ -104,7 +104,7 @@ func New(ctx context.Context, client client.Client, cfg config.UpdateCheckConfig
 		),
 	}
 
-	il.LoadingText = "Refreshing..."
+	il.LoadingText = "Loading..."
 	il.ActivePanelInitFn = func(item list.Item) string {
 		ii, ok := item.(imageItem)
 		if !ok {


### PR DESCRIPTION
Use `errgroup` to easily parrallelize requests when fetching resources through `List` commands 

We hit some limitations in the case of connecting to a docker client via `ssh`. The docker implementation of the ssh tunnel hit a limitation when it comes to  open parallel connections. To avoid we added a limit of concurrent connections `parallelInspectLimit `

We updated the `List` commands to use the [disk usage endpoint](https://docs.docker.com/reference/api/engine/version/v1.53/#tag/System/operation/SystemDataUsage) because in the case of Linux the image's container count was not being populated via the image list command. We changed the rest is to make the code more homogenous 