### PR TITLE
 Add system info modal with client integration and mock support

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -12,8 +12,34 @@ type Client interface {
 	Volumes() VolumeService
 	Networks() NetworkService
 	Compose() ComposeProjectService
+	Info(ctx context.Context) (SystemInfo, error)
 	Ping(ctx context.Context) error
 	Close() error
+}
+
+type SystemInfo struct {
+	DockerVersion    string
+	APIVersion       string
+	OS               string
+	Arch             string
+	Kernel           string
+	CPUs             int
+	TotalMemoryBytes int64
+	StorageDriver    StorageDriver
+	DiskUsage        DiskUsage
+	Warnings         []string
+}
+
+type StorageDriver struct {
+	Driver       string
+	DriverStatus [][2]string
+}
+
+type DiskUsage struct {
+	LayerSize      int64
+	ImagesSize     int64
+	VolumesSize    int64
+	ContainersSize int64
 }
 
 // ComposeUpOptions configures how a Compose project is brought up.

--- a/internal/client/docker.go
+++ b/internal/client/docker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/connhelper"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 
 	"github.com/GustavoCaso/docker-dash/internal/config"
@@ -94,6 +95,68 @@ func (c *dockerClient) Images() ImageService           { return c.images }
 func (c *dockerClient) Volumes() VolumeService         { return c.volumes }
 func (c *dockerClient) Networks() NetworkService       { return c.networks }
 func (c *dockerClient) Compose() ComposeProjectService { return c.compose }
+func (c *dockerClient) Info(ctx context.Context) (SystemInfo, error) {
+	systemInfo, err := c.cli.Info(ctx)
+	if err != nil {
+		return SystemInfo{}, err
+	}
+
+	diskUsage, err := c.cli.DiskUsage(ctx, types.DiskUsageOptions{
+		Types: []types.DiskUsageObject{
+			types.ContainerObject,
+			types.ImageObject,
+			types.VolumeObject,
+		},
+	})
+	if err != nil {
+		return SystemInfo{}, err
+	}
+
+	var (
+		imagesSize     int64
+		volumesSize    int64
+		containersSize int64
+	)
+
+	for _, usage := range diskUsage.Images {
+		if usage != nil {
+			imagesSize += usage.Size
+		}
+	}
+
+	for _, usage := range diskUsage.Volumes {
+		if usage != nil && usage.UsageData != nil {
+			volumesSize += usage.UsageData.Size
+		}
+	}
+
+	for _, usage := range diskUsage.Containers {
+		if usage != nil {
+			containersSize += usage.SizeRootFs
+		}
+	}
+
+	return SystemInfo{
+		DockerVersion:    systemInfo.ServerVersion,
+		APIVersion:       c.cli.ClientVersion(),
+		OS:               systemInfo.OSType,
+		Arch:             systemInfo.Architecture,
+		Kernel:           systemInfo.KernelVersion,
+		CPUs:             systemInfo.NCPU,
+		TotalMemoryBytes: systemInfo.MemTotal,
+		StorageDriver: StorageDriver{
+			Driver:       systemInfo.Driver,
+			DriverStatus: systemInfo.DriverStatus,
+		},
+		DiskUsage: DiskUsage{
+			LayerSize:      diskUsage.LayersSize,
+			ImagesSize:     imagesSize,
+			VolumesSize:    volumesSize,
+			ContainersSize: containersSize,
+		},
+		Warnings: systemInfo.Warnings,
+	}, nil
+}
 
 func (c *dockerClient) Ping(ctx context.Context) error {
 	log.Printf("[docker] Ping")

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -16,6 +16,7 @@ type MockClient struct {
 	volumes    *mockVolumeService
 	networks   *mockNetworkService
 	compose    *mockComposeProjectService
+	info       *mockSystemInfo
 }
 
 // NewMockClient creates a new mock Docker client with sample data.
@@ -26,16 +27,18 @@ func NewMockClient() *MockClient {
 		volumes:    newMockVolumeService(),
 		networks:   newMockNetworkService(),
 		compose:    newMockComposeProjectService(),
+		info:       newMockSystemInfo(),
 	}
 }
 
-func (c *MockClient) Containers() ContainerService   { return c.containers }
-func (c *MockClient) Images() ImageService           { return c.images }
-func (c *MockClient) Volumes() VolumeService         { return c.volumes }
-func (c *MockClient) Networks() NetworkService       { return c.networks }
-func (c *MockClient) Compose() ComposeProjectService { return c.compose }
-func (c *MockClient) Ping(ctx context.Context) error { return nil }
-func (c *MockClient) Close() error                   { return nil }
+func (c *MockClient) Containers() ContainerService                 { return c.containers }
+func (c *MockClient) Images() ImageService                         { return c.images }
+func (c *MockClient) Volumes() VolumeService                       { return c.volumes }
+func (c *MockClient) Networks() NetworkService                     { return c.networks }
+func (c *MockClient) Compose() ComposeProjectService               { return c.compose }
+func (c *MockClient) Info(ctx context.Context) (SystemInfo, error) { return c.info.SystemInfo, nil }
+func (c *MockClient) Ping(ctx context.Context) error               { return nil }
+func (c *MockClient) Close() error                                 { return nil }
 
 // mockContainerService provides mock container data.
 type mockContainerService struct {
@@ -832,4 +835,45 @@ func (s *mockComposeProjectService) setProjectState(project ComposeProject, stat
 	}
 
 	return fmt.Errorf("compose project not found: %s", project.Name)
+}
+
+type mockSystemInfo struct {
+	SystemInfo
+}
+
+func newMockSystemInfo() *mockSystemInfo {
+	return &mockSystemInfo{
+		SystemInfo{
+			DockerVersion:    "27.3.1",
+			APIVersion:       "1.46",
+			OS:               "linux",
+			Arch:             "amd64",
+			Kernel:           "6.1.0-amd64",
+			CPUs:             8,
+			TotalMemoryBytes: 16 * 1024 * 1024 * 1024,
+			StorageDriver: StorageDriver{
+				Driver: "overlay2",
+				DriverStatus: [][2]string{
+					{
+						"Backing Filesystem",
+						"extfs",
+					},
+					{
+						"Supports d_type",
+						"true",
+					},
+				},
+			},
+			DiskUsage: DiskUsage{
+				LayerSize:      2 * 1024 * 1024 * 1024,
+				ImagesSize:     1 * 1024 * 1024 * 1024,
+				VolumesSize:    512 * 1024 * 1024,
+				ContainersSize: 256 * 1024 * 1024,
+			},
+			Warnings: []string{
+				"WARNING: DOCKER_INSECURE_NO_IPTABLES_RAW is set",
+				"WARNING: daemon is not using the default seccomp profile",
+			},
+		},
+	}
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -221,13 +221,12 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if m.showSystemInfo {
 		km, ok := msg.(tea.KeyMsg)
-		if !ok {
-			return m, nil
-		}
-		switch km.String() {
-		case "esc", keys.Keys.SystemInfo.Keys()[0]:
-			m.showSystemInfo = false
-			return m, nil
+		if ok {
+			switch {
+			case key.Matches(km, m.keys.Esc), key.Matches(km, keys.Keys.SystemInfo):
+				m.showSystemInfo = false
+				return m, nil
+			}
 		}
 		return m, nil
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -256,6 +256,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.networkSection.SetSize(msg.Width, contentHeight)
 		m.composeSection.SetSize(msg.Width, contentHeight)
 		m.statusBar.SetSize(msg.Width, statusBarHeight)
+		m.systemInfo.SetSize(msg.Width, contentHeight)
 
 	case message.ShowConfirmationMsg:
 		log.Printf("[app] ShowConfirmationMsg: title=%q", msg.Title)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -162,7 +162,7 @@ func (m *model) Init() tea.Cmd {
 }
 
 func (m *model) handleFormUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if km, ok := msg.(tea.KeyMsg); ok && km.String() == "esc" { //nolint:goconst //multiple 'esc' declarations
+	if km, ok := msg.(tea.KeyMsg); ok && km.String() == "esc" {
 		m.showForm = false
 		m.formModel = nil
 		return m, nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/GustavoCaso/docker-dash/internal/ui/components/form"
 	"github.com/GustavoCaso/docker-dash/internal/ui/components/header"
 	"github.com/GustavoCaso/docker-dash/internal/ui/components/statusbar"
+	"github.com/GustavoCaso/docker-dash/internal/ui/components/systeminfo"
 	"github.com/GustavoCaso/docker-dash/internal/ui/helper"
 	"github.com/GustavoCaso/docker-dash/internal/ui/keys"
 	"github.com/GustavoCaso/docker-dash/internal/ui/message"
@@ -89,6 +90,8 @@ type model struct {
 	showConfirmation bool
 	showForm         bool
 	formModel        *form.Model
+	systemInfo       systeminfo.Model
+	showSystemInfo   bool
 	refreshInterval  time.Duration
 }
 
@@ -122,6 +125,7 @@ func New(ctx context.Context, version string, cfg *config.Config, client client.
 		volumeSection:    volumes.New(ctx, client.Volumes()),
 		networkSection:   networks.New(ctx, client.Networks()),
 		composeSection:   compose.New(ctx, client.Compose()),
+		systemInfo:       systeminfo.New(ctx, client),
 	}
 }
 
@@ -158,7 +162,7 @@ func (m *model) Init() tea.Cmd {
 }
 
 func (m *model) handleFormUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if km, ok := msg.(tea.KeyMsg); ok && km.String() == "esc" {
+	if km, ok := msg.(tea.KeyMsg); ok && km.String() == "esc" { //nolint:goconst //multiple 'esc' declarations
 		m.showForm = false
 		m.formModel = nil
 		return m, nil
@@ -213,6 +217,19 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if handled {
 			return model, cmd
 		}
+	}
+
+	if m.showSystemInfo {
+		km, ok := msg.(tea.KeyMsg)
+		if !ok {
+			return m, nil
+		}
+		switch km.String() {
+		case "esc", keys.Keys.SystemInfo.Keys()[0]:
+			m.showSystemInfo = false
+			return m, nil
+		}
+		return m, nil
 	}
 
 	switch msg := msg.(type) {
@@ -273,6 +290,40 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}))
 		return m, tea.Batch(cmds...)
 
+	case message.SystemInfoOutputMsg:
+		switch {
+		case msg.Err != nil:
+			m.showSystemInfo = false
+			return m, func() tea.Msg {
+				return message.ShowBannerMsg{
+					Message: fmt.Sprintf("failed to retrieve system information: %v", msg.Err),
+					IsError: true,
+				}
+			}
+
+		case msg.Info == nil:
+			m.showSystemInfo = false
+			return m, func() tea.Msg {
+				return message.ShowBannerMsg{
+					Message: "system information is not available",
+					IsError: true,
+				}
+			}
+		}
+
+		model, cmd := m.systemInfo.Update(msg)
+		systemModel, ok := model.(systeminfo.Model)
+		if !ok {
+			return m, nil
+		}
+		m.systemInfo = systemModel
+		m.showSystemInfo = true
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
+		return m, tea.Batch(cmds...)
+
 	case message.ShowSpinnerMsg:
 		log.Printf("[app] ShowSpinnerMsg: id=%q text=%q", msg.ID, msg.Text)
 		if cmd := m.showSpinner(msg); cmd != nil {
@@ -330,6 +381,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case key.Matches(msg, m.keys.Quit):
 			return m, tea.Quit
+		case key.Matches(msg, m.keys.SystemInfo):
+			if m.showSystemInfo {
+				m.showSystemInfo = false
+				return m, tea.Batch(cmds...)
+			}
+			cmds = append(cmds, m.systemInfo.Init())
+			return m, tea.Batch(cmds...)
 		case key.Matches(msg, m.keys.Left):
 			// section := m.activeSection()
 			m.header.MoveLeft()
@@ -392,6 +450,14 @@ func (m *model) View() string {
 			m.width, m.height,
 			lipgloss.Center, lipgloss.Center,
 			m.confirmation.View(),
+		)
+	}
+
+	if m.showSystemInfo {
+		return lipgloss.Place(
+			m.width, m.height,
+			lipgloss.Center, lipgloss.Center,
+			m.systemInfo.View(),
 		)
 	}
 

--- a/internal/ui/components/systeminfo/systeminfo.go
+++ b/internal/ui/components/systeminfo/systeminfo.go
@@ -1,0 +1,153 @@
+package systeminfo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/GustavoCaso/docker-dash/internal/client"
+	"github.com/GustavoCaso/docker-dash/internal/ui/message"
+	"github.com/GustavoCaso/docker-dash/internal/ui/theme"
+)
+
+const (
+	modalWidth   = 65
+	modalPadding = 2
+	modalHeight  = 30
+	columnGap    = 10
+)
+
+var (
+	modalStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(theme.Border).
+			AlignVertical(lipgloss.Top).
+			Padding(1, modalPadding).
+			Height(modalHeight).
+			Width(modalWidth)
+	titleStyle     = lipgloss.NewStyle().Bold(true)
+	diskTitleStyle = lipgloss.NewStyle().Bold(true)
+)
+
+type Model struct {
+	ctx        context.Context
+	client     client.Client
+	systemInfo *client.SystemInfo
+}
+
+func New(ctx context.Context, c client.Client) Model {
+	return Model{
+		ctx:    ctx,
+		client: c,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return func() tea.Msg {
+		systemInfo, err := m.client.Info(m.ctx)
+		if err != nil {
+			return message.SystemInfoOutputMsg{Err: err}
+		}
+		return message.SystemInfoOutputMsg{Info: &systemInfo}
+	}
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	sysMsg, ok := msg.(message.SystemInfoOutputMsg)
+	if !ok {
+		return m, nil
+	}
+
+	if sysMsg.Err != nil || sysMsg.Info == nil {
+		return m, nil
+	}
+
+	m.systemInfo = sysMsg.Info
+	return m, nil
+}
+
+func (m Model) View() string {
+	title := "System Information"
+
+	kernelTruncated := m.systemInfo.Kernel
+	if len(kernelTruncated) > 18 { //nolint:mnd // number of characters until it brokes the UI
+		kernelTruncated = kernelTruncated[:18] + "\n" + kernelTruncated[18:]
+	}
+
+	var driverStatus strings.Builder
+	for _, pair := range m.systemInfo.StorageDriver.DriverStatus {
+		key := pair[0]
+		value := pair[1]
+		maxValueLen := 20 - len(key) //nolint:mnd // truncate driver value if too large
+		if maxValueLen < 0 {
+			maxValueLen = 0
+		}
+		if len(value) > maxValueLen {
+			value = value[:maxValueLen] + "..."
+		}
+		fmt.Fprintf(&driverStatus, "\n%s: %s", key, value)
+	}
+
+	var leftCol strings.Builder
+	leftCol.WriteString("\n\n")
+	fmt.Fprintf(&leftCol, "Docker Version: %s\n\n", m.systemInfo.DockerVersion)
+	fmt.Fprintf(&leftCol, "API Version: %s\n\n", m.systemInfo.APIVersion)
+	fmt.Fprintf(&leftCol, "OS: %s\n\n", m.systemInfo.OS)
+	fmt.Fprintf(&leftCol, "Arch: %s\n\n", m.systemInfo.Arch)
+	fmt.Fprintf(&leftCol, "Kernel: %s\n\n", kernelTruncated)
+	fmt.Fprintf(&leftCol, "Driver: %s\n\n", m.systemInfo.StorageDriver.Driver)
+	fmt.Fprintf(&leftCol, "Driver Status:%s\n\n", driverStatus.String())
+
+	totalMem := formatBytes(m.systemInfo.TotalMemoryBytes)
+	layerSize := formatBytes(m.systemInfo.DiskUsage.LayerSize)
+	containersSize := formatBytes(m.systemInfo.DiskUsage.ContainersSize)
+	imagesSize := formatBytes(m.systemInfo.DiskUsage.ImagesSize)
+	volumesSize := formatBytes(m.systemInfo.DiskUsage.VolumesSize)
+
+	var rightCol strings.Builder
+	rightCol.WriteString("\n\n")
+	fmt.Fprintf(&rightCol, "CPUs: %d\n\n", m.systemInfo.CPUs)
+	fmt.Fprintf(&rightCol, "Total Memory: %s\n\n", totalMem)
+	rightCol.WriteString(diskTitleStyle.Render("Disk Usage") + "\n\n")
+	fmt.Fprintf(&rightCol, "Layer size: %s\n\n", layerSize)
+	fmt.Fprintf(&rightCol, "Containers size: %s\n\n", containersSize)
+	fmt.Fprintf(&rightCol, "Images size: %s\n\n", imagesSize)
+	fmt.Fprintf(&rightCol, "Volumes size: %s", volumesSize)
+
+	rightColStyle := lipgloss.NewStyle().PaddingLeft(columnGap)
+	columns := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		leftCol.String(),
+		rightColStyle.Render(rightCol.String()),
+	)
+
+	var warnings strings.Builder
+	if len(m.systemInfo.Warnings) > 0 {
+		warnings.WriteString("\nWarnings:\n")
+		for _, warning := range m.systemInfo.Warnings {
+			fmt.Fprintf(&warnings, "  - %s\n", warning)
+		}
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left, columns, warnings.String())
+	return modalStyle.Render(titleStyle.Render(title), content)
+}
+
+func formatBytes(b int64) string {
+	if b < 0 {
+		return "N/A"
+	}
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/ui/components/systeminfo/systeminfo.go
+++ b/internal/ui/components/systeminfo/systeminfo.go
@@ -13,23 +13,22 @@ import (
 	"github.com/GustavoCaso/docker-dash/internal/ui/theme"
 )
 
-const (
-	modalWidth   = 65
-	modalPadding = 2
-	modalHeight  = 30
-	columnGap    = 10
-)
-
 var (
 	modalStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(theme.Border).
-			AlignVertical(lipgloss.Top).
-			Padding(1, modalPadding).
-			Height(modalHeight).
-			Width(modalWidth)
-	titleStyle     = lipgloss.NewStyle().Bold(true)
-	diskTitleStyle = lipgloss.NewStyle().Bold(true)
+			Padding(1)
+	modalStyleX, modalStyleY = modalStyle.GetFrameSize()
+	titleStyle               = lipgloss.NewStyle().Bold(true)
+	diskTitleStyle           = lipgloss.NewStyle().Bold(true)
+)
+
+var (
+	modalWidth    = 100 - modalStyleX
+	columnsNumber = 2
+	columnsSize   = (modalWidth / columnsNumber) - modalStyleX
+	modalHeight   = 30 - modalStyleY
+	title         = titleStyle.Render("System Information")
 )
 
 type Model struct {
@@ -70,18 +69,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
-	title := "System Information"
-
 	kernelTruncated := m.systemInfo.Kernel
-	if len(kernelTruncated) > 18 { //nolint:mnd // number of characters until it brokes the UI
-		kernelTruncated = kernelTruncated[:18] + "\n" + kernelTruncated[18:]
+	if len(kernelTruncated) > columnsSize {
+		kernelTruncated = kernelTruncated[:columnsSize] + "\n" + kernelTruncated[columnsSize:]
 	}
 
 	var driverStatus strings.Builder
 	for _, pair := range m.systemInfo.StorageDriver.DriverStatus {
 		key := pair[0]
 		value := pair[1]
-		maxValueLen := 20 - len(key) //nolint:mnd // truncate driver value if too large
+		maxValueLen := columnsSize - len(key)
 		if maxValueLen < 0 {
 			maxValueLen = 0
 		}
@@ -117,11 +114,10 @@ func (m Model) View() string {
 	fmt.Fprintf(&rightCol, "Images size: %s\n\n", imagesSize)
 	fmt.Fprintf(&rightCol, "Volumes size: %s", volumesSize)
 
-	rightColStyle := lipgloss.NewStyle().PaddingLeft(columnGap)
 	columns := lipgloss.JoinHorizontal(
-		lipgloss.Top,
-		leftCol.String(),
-		rightColStyle.Render(rightCol.String()),
+		lipgloss.Left,
+		lipgloss.PlaceHorizontal(columnsSize, lipgloss.Center, leftCol.String()),
+		lipgloss.PlaceHorizontal(columnsSize, lipgloss.Center, rightCol.String()),
 	)
 
 	var warnings strings.Builder
@@ -132,8 +128,14 @@ func (m Model) View() string {
 		}
 	}
 
-	content := lipgloss.JoinVertical(lipgloss.Left, columns, warnings.String())
-	return modalStyle.Render(titleStyle.Render(title), content)
+	content := lipgloss.JoinVertical(
+		lipgloss.Top,
+		lipgloss.PlaceHorizontal(modalWidth, lipgloss.Center, title),
+		columns,
+		lipgloss.NewStyle().Width(modalWidth).Render(warnings.String()),
+	)
+
+	return modalStyle.Width(modalWidth).Height(modalHeight).Render(content)
 }
 
 func formatBytes(b int64) string {

--- a/internal/ui/components/systeminfo/systeminfo.go
+++ b/internal/ui/components/systeminfo/systeminfo.go
@@ -21,6 +21,7 @@ var (
 	modalStyleX, modalStyleY = modalStyle.GetFrameSize()
 	titleStyle               = lipgloss.NewStyle().Bold(true)
 	diskTitleStyle           = lipgloss.NewStyle().Bold(true)
+	hintStyle                = lipgloss.NewStyle().Faint(true)
 )
 
 const (
@@ -30,6 +31,7 @@ const (
 )
 
 var title = titleStyle.Render("System Information")
+var hintText = hintStyle.Render("[i/esc] exit")
 
 type Model struct {
 	ctx        context.Context
@@ -146,6 +148,7 @@ func (m Model) View() string {
 
 	content := lipgloss.JoinVertical(
 		lipgloss.Top,
+		lipgloss.PlaceHorizontal(modalWidth, lipgloss.Left, hintText),
 		lipgloss.PlaceHorizontal(modalWidth, lipgloss.Center, title),
 		columns,
 		lipgloss.NewStyle().Width(modalWidth).Render(warnings.String()),

--- a/internal/ui/components/systeminfo/systeminfo.go
+++ b/internal/ui/components/systeminfo/systeminfo.go
@@ -23,25 +23,34 @@ var (
 	diskTitleStyle           = lipgloss.NewStyle().Bold(true)
 )
 
-var (
-	modalWidth    = 100 - modalStyleX
-	columnsNumber = 2
-	columnsSize   = (modalWidth / columnsNumber) - modalStyleX
-	modalHeight   = 30 - modalStyleY
-	title         = titleStyle.Render("System Information")
+const (
+	defaultModalWidth  = 100
+	defaultModalHeight = 30
+	columnsNumber      = 2
 )
+
+var title = titleStyle.Render("System Information")
 
 type Model struct {
 	ctx        context.Context
 	client     client.Client
 	systemInfo *client.SystemInfo
+	width      int
+	height     int
 }
 
 func New(ctx context.Context, c client.Client) Model {
 	return Model{
 		ctx:    ctx,
 		client: c,
+		width:  defaultModalWidth,
+		height: defaultModalHeight,
 	}
+}
+
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
 }
 
 func (m Model) Init() tea.Cmd {
@@ -69,6 +78,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
+	modalWidth := m.width - modalStyleX
+	modalHeight := m.height - modalStyleY
+	columnsSize := (modalWidth / columnsNumber) - modalStyleX
+
+	if m.systemInfo == nil {
+		return modalStyle.Width(modalWidth).Height(modalHeight).Render(
+			lipgloss.Place(modalWidth, modalHeight, lipgloss.Center, lipgloss.Center, "Loading..."),
+		)
+	}
+
 	kernelTruncated := m.systemInfo.Kernel
 	if len(kernelTruncated) > columnsSize {
 		kernelTruncated = kernelTruncated[:columnsSize] + "\n" + kernelTruncated[columnsSize:]
@@ -78,10 +97,7 @@ func (m Model) View() string {
 	for _, pair := range m.systemInfo.StorageDriver.DriverStatus {
 		key := pair[0]
 		value := pair[1]
-		maxValueLen := columnsSize - len(key)
-		if maxValueLen < 0 {
-			maxValueLen = 0
-		}
+		maxValueLen := max(columnsSize-len(key), 0)
 		if len(value) > maxValueLen {
 			value = value[:maxValueLen] + "..."
 		}

--- a/internal/ui/components/systeminfo/systeminfo_test.go
+++ b/internal/ui/components/systeminfo/systeminfo_test.go
@@ -45,3 +45,30 @@ func TestSystemInfoView(t *testing.T) {
 		t.Errorf("view does not contain Arch")
 	}
 }
+
+func TestSystemInfoSetSize(t *testing.T) {
+	c := client.NewMockClient()
+	m := New(context.Background(), c)
+
+	m.width = defaultModalWidth
+	m.height = defaultModalHeight
+
+	m.SetSize(10, 10)
+
+	if m.width != 10 {
+		t.Fatalf("expected width to be 10 got %T", m.width)
+	}
+	if m.height != 10 {
+		t.Fatalf("expected height to be 10 got %T", m.height)
+	}
+}
+
+func TestSystemInfoViewWithoutInfo(t *testing.T) {
+	c := client.NewMockClient()
+	m := New(context.Background(), c)
+
+	view := m.View()
+	if !strings.Contains(view, "Loading") {
+		t.Errorf("view does not contain Loading state")
+	}
+}

--- a/internal/ui/components/systeminfo/systeminfo_test.go
+++ b/internal/ui/components/systeminfo/systeminfo_test.go
@@ -32,6 +32,9 @@ func TestSystemInfoView(t *testing.T) {
 	}
 
 	view := systemM.View()
+	if !strings.Contains(view, "[i/esc]") {
+		t.Errorf("view does not contain hint")
+	}
 	if !strings.Contains(view, systemM.systemInfo.DockerVersion) {
 		t.Errorf("view does not contain DockerVersion")
 	}

--- a/internal/ui/components/systeminfo/systeminfo_test.go
+++ b/internal/ui/components/systeminfo/systeminfo_test.go
@@ -1,0 +1,47 @@
+package systeminfo
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GustavoCaso/docker-dash/internal/client"
+	"github.com/GustavoCaso/docker-dash/internal/ui/message"
+)
+
+func TestSystemInfoView(t *testing.T) {
+	c := client.NewMockClient()
+	m := New(context.Background(), c)
+	cmd := m.Init()
+
+	msg, ok := cmd().(message.SystemInfoOutputMsg)
+	if !ok {
+		t.Fatalf("unexpected msg got= %T, expected= %T", msg, message.SystemInfoOutputMsg{})
+	}
+	if msg.Err != nil {
+		t.Fatalf("msg.Err got= %v, expected= nil", msg.Err)
+	}
+	if msg.Info == nil {
+		t.Fatalf("msg.Info got= %v, expected= %v", msg.Info, m.systemInfo)
+	}
+
+	model, _ := m.Update(msg)
+	systemM, ok := model.(Model)
+	if !ok {
+		t.Fatalf("unexpected model got= %T, expected= %T", model, Model{})
+	}
+
+	view := systemM.View()
+	if !strings.Contains(view, systemM.systemInfo.DockerVersion) {
+		t.Errorf("view does not contain DockerVersion")
+	}
+	if !strings.Contains(view, systemM.systemInfo.APIVersion) {
+		t.Errorf("view does not contain APIVersion")
+	}
+	if !strings.Contains(view, systemM.systemInfo.OS) {
+		t.Errorf("view does not contain OS")
+	}
+	if !strings.Contains(view, systemM.systemInfo.Arch) {
+		t.Errorf("view does not contain Arch")
+	}
+}

--- a/internal/ui/components/systeminfo/systeminfo_test.go
+++ b/internal/ui/components/systeminfo/systeminfo_test.go
@@ -56,10 +56,10 @@ func TestSystemInfoSetSize(t *testing.T) {
 	m.SetSize(10, 10)
 
 	if m.width != 10 {
-		t.Fatalf("expected width to be 10 got %T", m.width)
+		t.Fatalf("expected width to be 10 got %d", m.width)
 	}
 	if m.height != 10 {
-		t.Fatalf("expected height to be 10 got %T", m.height)
+		t.Fatalf("expected height to be 10 got %d", m.height)
 	}
 }
 

--- a/internal/ui/keys/keys.go
+++ b/internal/ui/keys/keys.go
@@ -40,8 +40,9 @@ type KeyMap struct {
 
 	Prune key.Binding
 
-	Help key.Binding
-	Quit key.Binding
+	SystemInfo key.Binding
+	Help       key.Binding
+	Quit       key.Binding
 }
 
 var navigation = key.NewBinding(
@@ -176,6 +177,10 @@ var Keys = &KeyMap{
 		key.WithKeys("P"),
 		key.WithHelp("P", "prune"),
 	),
+	SystemInfo: key.NewBinding(
+		key.WithKeys("i"),
+		key.WithHelp("i", "system info"),
+	),
 	Help: key.NewBinding(
 		key.WithKeys("?"),
 		key.WithHelp("?", "help"),
@@ -216,7 +221,8 @@ func (k KeyMap) ImageKeyMap() *ViewKeyMap {
 			{k.Left, k.Right, k.PanelNext, k.PanelPrev},
 			{k.Up, k.Down, k.ScrollUp, k.ScrollDown},
 			{k.Delete, k.CreateAndRunContainer, k.Prune, k.Filter},
-			{k.Help, k.Quit, k.PullImage, k.PullImageUpdate},
+			{k.PullImage, k.PullImageUpdate},
+			{k.Help, k.Quit, k.SystemInfo},
 		},
 		contextualKeys: []key.Binding{},
 	}
@@ -229,7 +235,8 @@ func (k KeyMap) ContainerKeyMap() *ViewKeyMap {
 			{k.Left, k.Right, k.PanelNext, k.PanelPrev},
 			{k.Up, k.Down, k.ScrollUp, k.ScrollDown},
 			{k.ContainerDelete, k.ContainerStartStop, k.ContainerRestart, k.Prune},
-			{k.ContainerPauseUnpause, k.Filter, k.Help, k.Quit},
+			{k.ContainerPauseUnpause, k.Filter},
+			{k.Help, k.Quit, k.SystemInfo},
 		},
 		contextualKeys: []key.Binding{},
 	}
@@ -242,7 +249,7 @@ func (k KeyMap) VolumeKeyMap() *ViewKeyMap {
 			{k.Left, k.Right, k.PanelNext, k.PanelPrev},
 			{k.Up, k.Down, k.ScrollUp, k.ScrollDown},
 			{k.Delete, k.Prune, k.Filter},
-			{k.Help, k.Quit},
+			{k.Help, k.Quit, k.SystemInfo},
 		},
 		contextualKeys: []key.Binding{},
 	}
@@ -255,7 +262,7 @@ func (k KeyMap) NetworkKeyMap() *ViewKeyMap {
 			{k.Left, k.Right, k.PanelNext, k.PanelPrev},
 			{k.Up, k.Down, k.ScrollUp, k.ScrollDown},
 			{k.NetworkDelete, k.Prune, k.Filter},
-			{k.Help, k.Quit},
+			{k.Help, k.Quit, k.SystemInfo},
 		},
 		contextualKeys: []key.Binding{},
 	}
@@ -269,7 +276,7 @@ func (k KeyMap) ComposeKeyMap() *ViewKeyMap {
 			{k.Up, k.Down, k.ScrollUp, k.ScrollDown},
 			{k.ComposeUp, k.ComposeDown, k.ComposeStartStop, k.ComposeRestart},
 			{k.Refresh, k.Filter},
-			{k.Help, k.Quit},
+			{k.Help, k.Quit, k.SystemInfo},
 		},
 		contextualKeys: []key.Binding{},
 	}

--- a/internal/ui/message/message.go
+++ b/internal/ui/message/message.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/GustavoCaso/docker-dash/internal/client"
 	"github.com/GustavoCaso/docker-dash/internal/ui/components/form"
 )
 
@@ -72,4 +73,9 @@ type ShowConfirmationMsg struct {
 
 type ShowFormMsg struct {
 	Form *form.Model
+}
+
+type SystemInfoOutputMsg struct {
+	Info *client.SystemInfo
+	Err  error
 }


### PR DESCRIPTION
Implements the system info overlay requested in #74 .

Changes:
- Adds `Info()` method to `Client` interface and mock implementation
- Adds `SystemInfoOutputMsg` to communicate fetch result between root `Update` and systeminfo `Update`
- Implements `systeminfo` UI component with two-column layout and warnings row
- Integrates modal into app with `i` keybinding
- Includes view test for system info rendering

<img width="1843" height="1030" alt="demo" src="https://github.com/user-attachments/assets/2958b764-8c08-4a43-9b79-9660f0f39ea7" />
