### PR TITLE
Add Container Kill action 

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -96,6 +96,7 @@ type ContainerService interface {
 	Stop(ctx context.Context, id string) error
 	Restart(ctx context.Context, id string) error
 	Remove(ctx context.Context, id string, force bool) error
+	Kill(ctx context.Context, id string, signal string) error
 	FileTree(ctx context.Context, id string) (*FileNode, error)
 	Logs(ctx context.Context, id string, opts LogOptions) (*LogsSession, error)
 	Exec(ctx context.Context, id string) (*ExecSession, error)

--- a/internal/client/docker.go
+++ b/internal/client/docker.go
@@ -170,6 +170,11 @@ func (c *dockerClient) Close() error {
 	return errors.Join(c.cli.Close(), c.compose.Close())
 }
 
+func (c *dockerClient) Kill(ctx context.Context, id string, signal string) error {
+	err := c.cli.ContainerKill(ctx, id, signal)
+	return err
+}
+
 // timeFromUnix converts Unix timestamp to time.Time.
 func timeFromUnix(unix int64) time.Time {
 	return time.Unix(unix, 0)

--- a/internal/client/docker_container_service.go
+++ b/internal/client/docker_container_service.go
@@ -281,6 +281,13 @@ func (s *containerService) Remove(ctx context.Context, id string, force bool) er
 	return err
 }
 
+func (s *containerService) Kill(ctx context.Context, id string, signal string) error {
+	log.Printf("[docker] ContainerKill: id=%q", id)
+	err := s.cli.ContainerKill(ctx, id, signal)
+	log.Printf("[docker] ContainerKill: done err=%v", id)
+	return err
+}
+
 func (s *containerService) Pause(ctx context.Context, id string) error {
 	log.Printf("[docker] ContainerPause: id=%q", id)
 	err := s.cli.ContainerPause(ctx, id)

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -31,14 +31,15 @@ func NewMockClient() *MockClient {
 	}
 }
 
-func (c *MockClient) Containers() ContainerService                 { return c.containers }
-func (c *MockClient) Images() ImageService                         { return c.images }
-func (c *MockClient) Volumes() VolumeService                       { return c.volumes }
-func (c *MockClient) Networks() NetworkService                     { return c.networks }
-func (c *MockClient) Compose() ComposeProjectService               { return c.compose }
-func (c *MockClient) Info(ctx context.Context) (SystemInfo, error) { return c.info.SystemInfo, nil }
-func (c *MockClient) Ping(ctx context.Context) error               { return nil }
-func (c *MockClient) Close() error                                 { return nil }
+func (c *MockClient) Containers() ContainerService                             { return c.containers }
+func (c *MockClient) Images() ImageService                                     { return c.images }
+func (c *MockClient) Volumes() VolumeService                                   { return c.volumes }
+func (c *MockClient) Networks() NetworkService                                 { return c.networks }
+func (c *MockClient) Compose() ComposeProjectService                           { return c.compose }
+func (c *MockClient) Info(ctx context.Context) (SystemInfo, error)             { return c.info.SystemInfo, nil }
+func (c *MockClient) Ping(ctx context.Context) error                           { return nil }
+func (c *MockClient) Close() error                                             { return nil }
+func (c *MockClient) Kill(ctx context.Context, id string, signal string) error { return nil }
 
 // mockContainerService provides mock container data.
 type mockContainerService struct {
@@ -329,6 +330,20 @@ func (s *mockContainerService) Remove(ctx context.Context, id string, force bool
 			return nil
 		}
 	}
+	return fmt.Errorf("container not found: %s", id)
+}
+
+func (s *mockContainerService) Kill(ctx context.Context, id, signal string) error {
+	for i, c := range s.containers {
+		if c.ID == id || c.Name == id {
+			if signal == "SIGKILL" {
+				s.containers[i].State = StateStopped
+				s.containers[i].Status = "Exited (137) 2 seconds ago"
+			}
+			return nil
+		}
+	}
+
 	return fmt.Errorf("container not found: %s", id)
 }
 

--- a/internal/ui/keys/keys.go
+++ b/internal/ui/keys/keys.go
@@ -27,6 +27,7 @@ type KeyMap struct {
 	ContainerStartStop    key.Binding
 	ContainerRestart      key.Binding
 	ContainerPauseUnpause key.Binding
+	ContainerKill         key.Binding
 
 	ComposeUp        key.Binding
 	ComposeDown      key.Binding
@@ -145,6 +146,10 @@ var Keys = &KeyMap{
 		key.WithKeys("p"),
 		key.WithHelp("p", "pause/unpause container"),
 	),
+	ContainerKill: key.NewBinding(
+		key.WithKeys("K"),
+		key.WithHelp("K", "kill container"),
+	),
 	ComposeUp: key.NewBinding(
 		key.WithKeys("u"),
 		key.WithHelp("u", "compose up"),
@@ -235,7 +240,7 @@ func (k KeyMap) ContainerKeyMap() *ViewKeyMap {
 			{k.Left, k.Right, k.PanelNext, k.PanelPrev},
 			{k.Up, k.Down, k.ScrollUp, k.ScrollDown},
 			{k.ContainerDelete, k.ContainerStartStop, k.ContainerRestart, k.Prune},
-			{k.ContainerPauseUnpause, k.Filter},
+			{k.ContainerPauseUnpause, k.ContainerKill, k.Filter},
 			{k.Help, k.Quit, k.SystemInfo},
 		},
 		contextualKeys: []key.Binding{},

--- a/internal/ui/sections/containers/section.go
+++ b/internal/ui/sections/containers/section.go
@@ -177,7 +177,7 @@ func (s *Section) handleMsg(msg tea.Msg) base.UpdateResult {
 		}
 		if msg.Action == "starting" || msg.Action == "stopping" || msg.Action == "restarting" ||
 			msg.Action == "pausing" ||
-			msg.Action == "unpausing" {
+			msg.Action == "unpausing" || msg.Action == "terminating" {
 			cmds = append(cmds, s.updateContainersCmd())
 			stopSpinner = false
 		}
@@ -219,6 +219,8 @@ func (s *Section) handleKey(msg tea.KeyMsg) base.UpdateResult {
 		return base.UpdateResult{Cmd: s.confirmContainerRestart(), Handled: true}
 	case key.Matches(msg, keys.Keys.ContainerPauseUnpause):
 		return base.UpdateResult{Cmd: s.confirmContainerPauseUnpause(), Handled: true}
+	case key.Matches(msg, keys.Keys.ContainerKill):
+		return base.UpdateResult{Cmd: s.confirmContainerKill(), Handled: true}
 	}
 	return base.UpdateResult{}
 }
@@ -288,6 +290,26 @@ func (s *Section) restartContainerCmd() tea.Cmd {
 	return func() tea.Msg {
 		err := svc.Restart(s.ctx, ci.ID())
 		return containerActionMsg{ID: ci.ID(), Action: "restarting", Idx: idx, Error: err}
+	}
+}
+
+func (s *Section) killContainerCmd() tea.Cmd {
+	ctx := s.ctx
+	svc := s.service
+	items := s.List.Items()
+	idx := s.List.Index()
+	if idx < 0 || idx >= len(items) {
+		return nil
+	}
+
+	ci, ok := items[idx].(containerItem)
+	if !ok {
+		return nil
+	}
+
+	return func() tea.Msg {
+		err := svc.Kill(ctx, ci.ID(), "SIGKILL")
+		return containerActionMsg{ID: ci.ID(), Action: "terminating", Idx: idx, Error: err}
 	}
 }
 
@@ -370,6 +392,23 @@ func (s *Section) confirmContainerDelete() tea.Cmd {
 			Title:     "Delete Container",
 			Body:      fmt.Sprintf("Delete container %s?", helper.ShortID(ci.ID())),
 			OnConfirm: s.WithSpinner(deleteCmd),
+		}
+	}
+}
+
+func (s *Section) confirmContainerKill() tea.Cmd {
+	items := s.List.Items()
+	idx := s.List.Index()
+	if idx < 0 || idx >= len(items) {
+		return nil
+	}
+
+	killCmd := s.killContainerCmd()
+	return func() tea.Msg {
+		return message.ShowConfirmationMsg{
+			Title:     "Kill Container",
+			Body:      "Force kill container ? This sends SIGKILL",
+			OnConfirm: s.WithSpinner(killCmd),
 		}
 	}
 }

--- a/internal/ui/sections/containers/section_test.go
+++ b/internal/ui/sections/containers/section_test.go
@@ -255,6 +255,16 @@ func TestContainerPauseUnpause(t *testing.T) {
 	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
 }
 
+func TestContainerKill(t *testing.T) {
+	model := newContainerSectionModel()
+	tm := teatest.NewTestModel(t, model, teatest.WithInitialTermSize(120, 40))
+	waitFor(t, tm, "nginx:latest")
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("K")})
+	waitFor(t, tm, "stopped")
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
+}
+
 func TestFormatBytes(t *testing.T) {
 	tests := []struct {
 		input    uint64


### PR DESCRIPTION
Implement container kill action as sugested in  #62.

Changes:
- Adds Kill() method to `ContainerService` interface and mock implementation
- Integrates action with `K` keybinding and added it to help overlay
<img width="1843" height="1030" alt="demo" src="https://github.com/user-attachments/assets/377a4f04-cd56-4bd8-8b1b-fd70fffac48e" />

