### PR TITLE
use huh form to capture compose operations options

### DIFF
--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -15,7 +15,7 @@ type MockClient struct {
 	images     *mockImageService
 	volumes    *mockVolumeService
 	networks   *mockNetworkService
-	compose    *mockComposeProjectService
+	compose    *MockComposeProjectService
 	info       *mockSystemInfo
 }
 
@@ -26,7 +26,7 @@ func NewMockClient() *MockClient {
 		images:     newMockImageService(),
 		volumes:    newMockVolumeService(),
 		networks:   newMockNetworkService(),
-		compose:    newMockComposeProjectService(),
+		compose:    NewMockComposeProjectService(),
 		info:       newMockSystemInfo(),
 	}
 }
@@ -775,13 +775,17 @@ func (s *mockNetworkService) Prune(_ context.Context, _ PruneOptions) (PruneRepo
 	return PruneReport{ItemsDeleted: count, SpaceReclaimed: 0}, nil
 }
 
-// mockComposeProjectService provides mock Compose project data.
-type mockComposeProjectService struct {
-	projects []ComposeProject
+// MockComposeProjectService provides mock Compose project data.
+type MockComposeProjectService struct {
+	projects        []ComposeProject
+	LastUpOpts      ComposeUpOptions
+	LastDownOpts    ComposeDownOptions
+	LastStopOpts    ComposeStopOptions
+	LastRestartOpts ComposeRestartOptions
 }
 
-func newMockComposeProjectService() *mockComposeProjectService {
-	return &mockComposeProjectService{
+func NewMockComposeProjectService() *MockComposeProjectService {
+	return &MockComposeProjectService{
 		projects: []ComposeProject{
 			{
 				Name:        "web-app",
@@ -806,15 +810,17 @@ func newMockComposeProjectService() *mockComposeProjectService {
 	}
 }
 
-func (s *mockComposeProjectService) List(_ context.Context) ([]ComposeProject, error) {
+func (s *MockComposeProjectService) List(_ context.Context) ([]ComposeProject, error) {
 	return s.projects, nil
 }
 
-func (s *mockComposeProjectService) Up(_ context.Context, project ComposeProject, _ ComposeUpOptions) error {
+func (s *MockComposeProjectService) Up(_ context.Context, project ComposeProject, opts ComposeUpOptions) error {
+	s.LastUpOpts = opts
 	return s.setProjectState(project, "running")
 }
 
-func (s *mockComposeProjectService) Down(_ context.Context, project ComposeProject, _ ComposeDownOptions) error {
+func (s *MockComposeProjectService) Down(_ context.Context, project ComposeProject, opts ComposeDownOptions) error {
+	s.LastDownOpts = opts
 	for idx, existing := range s.projects {
 		if existing.Identity() == project.Identity() {
 			s.projects = append(s.projects[:idx], s.projects[idx+1:]...)
@@ -825,19 +831,25 @@ func (s *mockComposeProjectService) Down(_ context.Context, project ComposeProje
 	return fmt.Errorf("compose project not found: %s", project.Name)
 }
 
-func (s *mockComposeProjectService) Start(_ context.Context, project ComposeProject, _ ComposeStartOptions) error {
+func (s *MockComposeProjectService) Start(_ context.Context, project ComposeProject, _ ComposeStartOptions) error {
 	return s.setProjectState(project, "running")
 }
 
-func (s *mockComposeProjectService) Stop(_ context.Context, project ComposeProject, _ ComposeStopOptions) error {
+func (s *MockComposeProjectService) Stop(_ context.Context, project ComposeProject, opts ComposeStopOptions) error {
+	s.LastStopOpts = opts
 	return s.setProjectState(project, "exited")
 }
 
-func (s *mockComposeProjectService) Restart(_ context.Context, project ComposeProject, _ ComposeRestartOptions) error {
+func (s *MockComposeProjectService) Restart(
+	_ context.Context,
+	project ComposeProject,
+	opts ComposeRestartOptions,
+) error {
+	s.LastRestartOpts = opts
 	return s.setProjectState(project, "running")
 }
 
-func (s *mockComposeProjectService) setProjectState(project ComposeProject, state string) error {
+func (s *MockComposeProjectService) setProjectState(project ComposeProject, state string) error {
 	for projectIdx, existing := range s.projects {
 		if existing.Identity() != project.Identity() {
 			continue

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"time"
 )
@@ -823,7 +824,7 @@ func (s *MockComposeProjectService) Down(_ context.Context, project ComposeProje
 	s.LastDownOpts = opts
 	for idx, existing := range s.projects {
 		if existing.Identity() == project.Identity() {
-			s.projects = append(s.projects[:idx], s.projects[idx+1:]...)
+			s.projects = slices.Delete(s.projects, idx, idx+1)
 			return nil
 		}
 	}

--- a/internal/ui/keys/keys.go
+++ b/internal/ui/keys/keys.go
@@ -142,8 +142,8 @@ var Keys = &KeyMap{
 		key.WithHelp("s", "start/stop container"),
 	),
 	ContainerRestart: key.NewBinding(
-		key.WithKeys("ctrl+R"),
-		key.WithHelp("ctrl+R", "restart container"),
+		key.WithKeys("R"),
+		key.WithHelp("R", "restart container"),
 	),
 	ContainerPauseUnpause: key.NewBinding(
 		key.WithKeys("p"),
@@ -166,8 +166,8 @@ var Keys = &KeyMap{
 		key.WithHelp("s", "start/stop project"),
 	),
 	ComposeRestart: key.NewBinding(
-		key.WithKeys("ctrl+R"),
-		key.WithHelp("ctrl+R", "restart project"),
+		key.WithKeys("R"),
+		key.WithHelp("R", "restart project"),
 	),
 	NetworkDelete: key.NewBinding(
 		key.WithKeys("D"),

--- a/internal/ui/sections/compose/section.go
+++ b/internal/ui/sections/compose/section.go
@@ -432,10 +432,11 @@ func composeRestartForm(noDeps *bool, timeout *string) *huh.Form {
 }
 
 func validateOptionalDuration(s string) error {
-	if strings.TrimSpace(s) == "" {
+	t := strings.TrimSpace(s)
+	if t == "" {
 		return nil
 	}
-	_, err := time.ParseDuration(s)
+	_, err := time.ParseDuration(t)
 	if err != nil {
 		return fmt.Errorf("invalid duration %q: use Go format e.g. 10s, 1m30s", s)
 	}

--- a/internal/ui/sections/compose/section.go
+++ b/internal/ui/sections/compose/section.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 
 	"github.com/GustavoCaso/docker-dash/internal/client"
+	"github.com/GustavoCaso/docker-dash/internal/ui/components/form"
 	"github.com/GustavoCaso/docker-dash/internal/ui/components/panel"
 	"github.com/GustavoCaso/docker-dash/internal/ui/keys"
 	"github.com/GustavoCaso/docker-dash/internal/ui/message"
@@ -141,13 +144,13 @@ func (s *Section) handleMsg(msg tea.Msg) base.UpdateResult {
 func (s *Section) handleKey(msg tea.KeyMsg) base.UpdateResult {
 	switch {
 	case key.Matches(msg, keys.Keys.ComposeUp):
-		return base.UpdateResult{Cmd: s.confirmProjectUp(), Handled: true}
+		return base.UpdateResult{Cmd: s.showUpForm(), Handled: true}
 	case key.Matches(msg, keys.Keys.ComposeDown):
-		return base.UpdateResult{Cmd: s.confirmProjectDown(), Handled: true}
+		return base.UpdateResult{Cmd: s.showDownForm(), Handled: true}
 	case key.Matches(msg, keys.Keys.ComposeStartStop):
 		return base.UpdateResult{Cmd: s.confirmProjectToggle(), Handled: true}
 	case key.Matches(msg, keys.Keys.ComposeRestart):
-		return base.UpdateResult{Cmd: s.confirmProjectRestart(), Handled: true}
+		return base.UpdateResult{Cmd: s.showRestartForm(), Handled: true}
 	}
 
 	return base.UpdateResult{}
@@ -184,26 +187,26 @@ func (s *Section) selectedProject() (client.ComposeProject, bool) {
 	return item.project, true
 }
 
-func (s *Section) projectUpCmd() tea.Cmd {
+func (s *Section) projectUpCmd(opts client.ComposeUpOptions) tea.Cmd {
 	project, ok := s.selectedProject()
 	if !ok {
 		return nil
 	}
 
 	return func() tea.Msg {
-		err := s.composeService.Up(s.ctx, project, client.ComposeUpOptions{})
+		err := s.composeService.Up(s.ctx, project, opts)
 		return composeActionMsg{project: project, action: "up", err: err}
 	}
 }
 
-func (s *Section) projectDownCmd() tea.Cmd {
+func (s *Section) projectDownCmd(opts client.ComposeDownOptions) tea.Cmd {
 	project, ok := s.selectedProject()
 	if !ok {
 		return nil
 	}
 
 	return func() tea.Msg {
-		err := s.composeService.Down(s.ctx, project, client.ComposeDownOptions{})
+		err := s.composeService.Down(s.ctx, project, opts)
 		return composeActionMsg{project: project, action: "down", err: err}
 	}
 }
@@ -232,47 +235,66 @@ func (s *Section) projectToggleCmd() tea.Cmd {
 	}
 }
 
-func (s *Section) projectRestartCmd() tea.Cmd {
+func (s *Section) projectRestartCmd(opts client.ComposeRestartOptions) tea.Cmd {
 	project, ok := s.selectedProject()
 	if !ok {
 		return nil
 	}
 
 	return func() tea.Msg {
-		err := s.composeService.Restart(s.ctx, project, client.ComposeRestartOptions{})
+		err := s.composeService.Restart(s.ctx, project, opts)
 		return composeActionMsg{project: project, action: "restarted", err: err}
 	}
 }
 
-func (s *Section) confirmProjectUp() tea.Cmd {
+func (s *Section) showUpForm() tea.Cmd {
 	project, ok := s.selectedProject()
 	if !ok {
 		return nil
 	}
 
-	upCmd := s.projectUpCmd()
+	var build, removeOrphans, wait bool
+	f := composeUpForm(&build, &removeOrphans, &wait)
+	upForm := form.New(
+		fmt.Sprintf("Up — %s", project.Name),
+		f,
+		func(_ *huh.Form) tea.Cmd {
+			opts := client.ComposeUpOptions{
+				Build:         build,
+				RemoveOrphans: removeOrphans,
+				Wait:          wait,
+			}
+			return s.WithSpinner(s.projectUpCmd(opts))
+		},
+	)
 	return func() tea.Msg {
-		return message.ShowConfirmationMsg{
-			Title:     "Compose Up",
-			Body:      fmt.Sprintf("Run compose up for project %s?", project.Name),
-			OnConfirm: s.WithSpinner(upCmd),
-		}
+		return message.ShowFormMsg{Form: upForm}
 	}
 }
 
-func (s *Section) confirmProjectDown() tea.Cmd {
+func (s *Section) showDownForm() tea.Cmd {
 	project, ok := s.selectedProject()
 	if !ok {
 		return nil
 	}
 
-	downCmd := s.projectDownCmd()
+	var removeOrphans, volumes bool
+	var images string
+	f := composeDownForm(&removeOrphans, &volumes, &images)
+	downForm := form.New(
+		fmt.Sprintf("Down — %s", project.Name),
+		f,
+		func(_ *huh.Form) tea.Cmd {
+			opts := client.ComposeDownOptions{
+				RemoveOrphans: removeOrphans,
+				Volumes:       volumes,
+				Images:        images,
+			}
+			return s.WithSpinner(s.projectDownCmd(opts))
+		},
+	)
 	return func() tea.Msg {
-		return message.ShowConfirmationMsg{
-			Title:     "Compose Down",
-			Body:      fmt.Sprintf("Run compose down for project %s?", project.Name),
-			OnConfirm: s.WithSpinner(downCmd),
-		}
+		return message.ShowFormMsg{Form: downForm}
 	}
 }
 
@@ -297,20 +319,35 @@ func (s *Section) confirmProjectToggle() tea.Cmd {
 	}
 }
 
-func (s *Section) confirmProjectRestart() tea.Cmd {
+func (s *Section) showRestartForm() tea.Cmd {
 	project, ok := s.selectedProject()
 	if !ok {
 		return nil
 	}
 
-	restartCmd := s.projectRestartCmd()
+	var noDeps bool
+	var timeoutStr string
+	f := composeRestartForm(&noDeps, &timeoutStr)
+	restartForm := form.New(
+		fmt.Sprintf("Restart — %s", project.Name),
+		f,
+		func(_ *huh.Form) tea.Cmd {
+			return s.WithSpinner(s.projectRestartCmd(buildRestartOptions(noDeps, timeoutStr)))
+		},
+	)
 	return func() tea.Msg {
-		return message.ShowConfirmationMsg{
-			Title:     "Restart Compose Project",
-			Body:      fmt.Sprintf("Restart compose project %s?", project.Name),
-			OnConfirm: s.WithSpinner(restartCmd),
+		return message.ShowFormMsg{Form: restartForm}
+	}
+}
+
+func buildRestartOptions(noDeps bool, timeoutStr string) client.ComposeRestartOptions {
+	opts := client.ComposeRestartOptions{NoDeps: noDeps}
+	if t := strings.TrimSpace(timeoutStr); t != "" {
+		if d, err := time.ParseDuration(t); err == nil {
+			opts.Timeout = &d
 		}
 	}
+	return opts
 }
 
 func projectHasRunningServices(project client.ComposeProject) bool {
@@ -321,4 +358,86 @@ func projectHasRunningServices(project client.ComposeProject) bool {
 	}
 
 	return false
+}
+
+func composeUpForm(build, removeOrphans, wait *bool) *huh.Form {
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Key("build").
+				Title("Build").
+				Description("Rebuild images before starting containers.").
+				Value(build),
+
+			huh.NewConfirm().
+				Key("remove_orphans").
+				Title("Remove Orphans").
+				Description("Remove containers for services not defined in the Compose file.").
+				Value(removeOrphans),
+
+			huh.NewConfirm().
+				Key("wait").
+				Title("Wait").
+				Description("Wait for services to be healthy before returning.").
+				Value(wait),
+		),
+	)
+}
+
+func composeDownForm(removeOrphans, volumes *bool, images *string) *huh.Form {
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Key("remove_orphans").
+				Title("Remove Orphans").
+				Description("Remove containers for services not defined in the Compose file.").
+				Value(removeOrphans),
+
+			huh.NewConfirm().
+				Key("volumes").
+				Title("Remove Volumes").
+				Description("Remove named volumes declared in the Compose file.").
+				Value(volumes),
+
+			huh.NewSelect[string]().
+				Key("images").
+				Title("Remove Images").
+				Value(images).
+				Options(
+					huh.NewOption("none", ""),
+					huh.NewOption("local (images without a custom tag)", "local"),
+					huh.NewOption("all (all images used by services)", "all"),
+				),
+		),
+	)
+}
+
+func composeRestartForm(noDeps *bool, timeout *string) *huh.Form {
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Key("no_deps").
+				Title("No Deps").
+				Description("Don't restart dependent services.").
+				Value(noDeps),
+
+			huh.NewInput().
+				Key("timeout").
+				Title("Timeout").
+				Description("Shutdown timeout before killing (e.g. 10s, 1m). Leave blank for default.").
+				Value(timeout).
+				Validate(validateOptionalDuration),
+		),
+	)
+}
+
+func validateOptionalDuration(s string) error {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	_, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: use Go format e.g. 10s, 1m30s", s)
+	}
+	return nil
 }

--- a/internal/ui/sections/compose/section_test.go
+++ b/internal/ui/sections/compose/section_test.go
@@ -317,6 +317,7 @@ func TestValidateOptionalDuration(t *testing.T) {
 		{"", false},
 		{"   ", false},
 		{"10s", false},
+		{" 10s ", false},
 		{"1m30s", false},
 		{"500ms", false},
 		{"garbage", true},

--- a/internal/ui/sections/compose/section_test.go
+++ b/internal/ui/sections/compose/section_test.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -96,25 +97,6 @@ func TestComposeRefresh(t *testing.T) {
 	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
 }
 
-func TestComposeKeyShowsConfirmation(t *testing.T) {
-	model := newModel()
-
-	cmd := model.section.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
-	if cmd == nil {
-		t.Fatal("expected confirmation command")
-	}
-
-	msg := cmd()
-	confirmation, ok := msg.(message.ShowConfirmationMsg)
-	if !ok {
-		t.Fatalf("expected ShowConfirmationMsg, got %T", msg)
-	}
-
-	if confirmation.Title != "Compose Up" {
-		t.Fatalf("unexpected confirmation title: %s", confirmation.Title)
-	}
-}
-
 func TestComposeLoadedMsgRefreshesActivePanel(t *testing.T) {
 	model := newModel()
 
@@ -180,5 +162,281 @@ func TestComposeLoadedMsgEmptyCallsUpdateItemsReset(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Error("Update should return a non-nil cmd (SetItems) after empty composeLoadedMsg")
+	}
+}
+
+func TestComposeKeyShowsForm(t *testing.T) {
+	tests := []struct {
+		name   string
+		keyMsg tea.KeyMsg
+	}{
+		{"up", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")}},
+		{"down", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")}},
+		{"restart", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := newModel()
+			cmd := model.section.Update(tt.keyMsg)
+			if cmd == nil {
+				t.Fatal("expected form command, got nil")
+			}
+			msg := cmd()
+			formMsg, ok := msg.(message.ShowFormMsg)
+			if !ok {
+				t.Fatalf("expected ShowFormMsg, got %T", msg)
+			}
+			if formMsg.Form == nil {
+				t.Fatal("expected non-nil form")
+			}
+		})
+	}
+}
+
+func TestComposeStartStopShowsConfirmation(t *testing.T) {
+	model := newModel()
+
+	cmd := model.section.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	if cmd == nil {
+		t.Fatal("expected confirmation command, got nil")
+	}
+	msg := cmd()
+	confirm, ok := msg.(message.ShowConfirmationMsg)
+	if !ok {
+		t.Fatalf("expected ShowConfirmationMsg, got %T", msg)
+	}
+	if confirm.OnConfirm == nil {
+		t.Fatal("expected non-nil OnConfirm")
+	}
+}
+
+func TestComposeActionMsgSuccess(t *testing.T) {
+	model := newModel()
+	project := client.ComposeProject{Name: "web-app"}
+
+	result := model.section.handleMsg(composeActionMsg{project: project, action: "up", err: nil})
+
+	if !result.Handled {
+		t.Fatal("expected composeActionMsg to be handled")
+	}
+	if result.Cmd == nil {
+		t.Fatal("expected non-nil cmd (refresh + banner)")
+	}
+}
+
+func TestComposeActionMsgError(t *testing.T) {
+	model := newModel()
+	project := client.ComposeProject{Name: "web-app"}
+
+	result := model.section.handleMsg(composeActionMsg{
+		project: project,
+		action:  "up",
+		err:     errors.New("daemon unreachable"),
+	})
+
+	if !result.Handled {
+		t.Fatal("expected composeActionMsg error to be handled")
+	}
+	if result.Cmd == nil {
+		t.Fatal("expected error banner cmd")
+	}
+	bannerMsg, ok := result.Cmd().(message.ShowBannerMsg)
+	if !ok {
+		t.Fatalf("expected ShowBannerMsg, got %T", result.Cmd())
+	}
+	if !bannerMsg.IsError {
+		t.Error("expected IsError=true")
+	}
+}
+
+func TestComposeLoadedMsgError(t *testing.T) {
+	model := newModel()
+
+	result := model.section.handleMsg(composeLoadedMsg{error: errors.New("connection refused")})
+
+	if !result.Handled {
+		t.Fatal("expected handled")
+	}
+	if !result.StopSpinner {
+		t.Error("expected StopSpinner on error")
+	}
+	bannerMsg, ok := result.Cmd().(message.ShowBannerMsg)
+	if !ok {
+		t.Fatalf("expected ShowBannerMsg, got %T", result.Cmd())
+	}
+	if !bannerMsg.IsError {
+		t.Error("expected IsError=true")
+	}
+}
+
+func TestBuildRestartOptions(t *testing.T) {
+	tenSec := 10 * time.Second
+	oneMin := time.Minute
+
+	tests := []struct {
+		name        string
+		noDeps      bool
+		timeoutStr  string
+		wantNoDeps  bool
+		wantTimeout *time.Duration
+	}{
+		{"defaults", false, "", false, nil},
+		{"noDeps set", true, "", true, nil},
+		{"timeout set", false, "10s", false, &tenSec},
+		{"noDeps and timeout", true, "1m", true, &oneMin},
+		{"whitespace timeout", false, "  ", false, nil},
+		{"invalid timeout ignored", false, "garbage", false, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := buildRestartOptions(tt.noDeps, tt.timeoutStr)
+			if opts.NoDeps != tt.wantNoDeps {
+				t.Errorf("NoDeps: got %v, want %v", opts.NoDeps, tt.wantNoDeps)
+			}
+			if tt.wantTimeout == nil && opts.Timeout != nil {
+				t.Errorf("Timeout: got %v, want nil", opts.Timeout)
+			}
+			if tt.wantTimeout != nil {
+				if opts.Timeout == nil {
+					t.Errorf("Timeout: got nil, want %v", *tt.wantTimeout)
+				} else if *opts.Timeout != *tt.wantTimeout {
+					t.Errorf("Timeout: got %v, want %v", *opts.Timeout, *tt.wantTimeout)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateOptionalDuration(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantErr bool
+	}{
+		{"", false},
+		{"   ", false},
+		{"10s", false},
+		{"1m30s", false},
+		{"500ms", false},
+		{"garbage", true},
+		{"10", true},
+	}
+
+	for _, tt := range tests {
+		err := validateOptionalDuration(tt.input)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("validateOptionalDuration(%q): wantErr=%v, got %v", tt.input, tt.wantErr, err)
+		}
+	}
+}
+
+func TestComposeUpOptsReachClient(t *testing.T) {
+	c := client.NewMockClient()
+	section := New(context.Background(), c.Compose())
+	section.SetSize(120, 40)
+	section.Update(section.RefreshCmd()())
+
+	opts := client.ComposeUpOptions{Build: true, RemoveOrphans: true, Wait: false}
+	cmd := section.projectUpCmd(opts)
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	msg := cmd()
+	actionMsg, ok := msg.(composeActionMsg)
+	if !ok {
+		t.Fatalf("expected composeActionMsg, got %T", msg)
+	}
+	if actionMsg.err != nil {
+		t.Fatalf("unexpected error: %v", actionMsg.err)
+	}
+	mock, ok := c.Compose().(*client.MockComposeProjectService)
+	if !ok {
+		t.Fatal("expected *client.MockComposeProjectService")
+	}
+	if mock.LastUpOpts.Build != opts.Build {
+		t.Errorf("Build: got %v, want %v", mock.LastUpOpts.Build, opts.Build)
+	}
+	if mock.LastUpOpts.RemoveOrphans != opts.RemoveOrphans {
+		t.Errorf("RemoveOrphans: got %v, want %v", mock.LastUpOpts.RemoveOrphans, opts.RemoveOrphans)
+	}
+}
+
+func TestComposeDownOptsReachClient(t *testing.T) {
+	c := client.NewMockClient()
+	section := New(context.Background(), c.Compose())
+	section.SetSize(120, 40)
+	section.Update(section.RefreshCmd()())
+
+	opts := client.ComposeDownOptions{RemoveOrphans: true}
+	cmd := section.projectDownCmd(opts)
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	msg := cmd()
+	actionMsg, ok := msg.(composeActionMsg)
+	if !ok {
+		t.Fatalf("expected composeActionMsg, got %T", msg)
+	}
+	if actionMsg.err != nil {
+		t.Fatalf("unexpected error: %v", actionMsg.err)
+	}
+	mock, ok := c.Compose().(*client.MockComposeProjectService)
+	if !ok {
+		t.Fatal("expected *client.MockComposeProjectService")
+	}
+	if mock.LastDownOpts.RemoveOrphans != opts.RemoveOrphans {
+		t.Errorf("RemoveOrphans: got %v, want %v", mock.LastDownOpts.RemoveOrphans, opts.RemoveOrphans)
+	}
+}
+
+func TestComposeRestartOptsReachClient(t *testing.T) {
+	c := client.NewMockClient()
+	section := New(context.Background(), c.Compose())
+	section.SetSize(120, 40)
+	section.Update(section.RefreshCmd()())
+
+	timeout := 30 * time.Second
+	opts := client.ComposeRestartOptions{NoDeps: true, Timeout: &timeout}
+	cmd := section.projectRestartCmd(opts)
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	msg := cmd()
+	actionMsg, ok := msg.(composeActionMsg)
+	if !ok {
+		t.Fatalf("expected composeActionMsg, got %T", msg)
+	}
+	if actionMsg.err != nil {
+		t.Fatalf("unexpected error: %v", actionMsg.err)
+	}
+	mock, ok := c.Compose().(*client.MockComposeProjectService)
+	if !ok {
+		t.Fatal("expected *client.MockComposeProjectService")
+	}
+	if !mock.LastRestartOpts.NoDeps {
+		t.Error("NoDeps: got false, want true")
+	}
+	if mock.LastRestartOpts.Timeout == nil || *mock.LastRestartOpts.Timeout != timeout {
+		t.Errorf("Timeout: got %v, want %v", mock.LastRestartOpts.Timeout, timeout)
+	}
+}
+
+func TestComposeFormKeysReturnNilOnEmptyList(t *testing.T) {
+	c := client.NewMockClient()
+	section := New(context.Background(), c.Compose())
+	section.SetSize(120, 40)
+	// Do NOT load items — list is empty, selectedProject() returns false.
+
+	for _, key := range []tea.Msg{
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")},
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")},
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")},
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")},
+	} {
+		cmd := section.Update(key)
+		if cmd != nil {
+			t.Errorf("expected nil cmd for key %v on empty list, got non-nil", key)
+		}
 	}
 }


### PR DESCRIPTION
Use a form to capture compose option for the Up, Down, and Restart operations

<img width="1275" height="708" alt="image" src="https://github.com/user-attachments/assets/d5663d0f-3adf-43c4-8262-6830ae4256ba" />


Changed the key binging for restarting to `R` for compose and container sections
