### PR TITLE
Add copy from container to host support

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"io"
 	"time"
 )
 
@@ -104,6 +105,7 @@ type ContainerService interface {
 	Prune(ctx context.Context, opts PruneOptions) (PruneReport, error)
 	Pause(ctx context.Context, id string) error
 	Unpause(ctx context.Context, id string) error
+	CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, error)
 }
 
 // ImageService manages Docker images.

--- a/internal/client/docker_container_service.go
+++ b/internal/client/docker_container_service.go
@@ -302,6 +302,13 @@ func (s *containerService) Unpause(ctx context.Context, id string) error {
 	return err
 }
 
+func (s *containerService) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, error) {
+	log.Printf("[docker] CopyFromContainer: id=%q", containerID)
+	rc, _, err := s.cli.CopyFromContainer(ctx, containerID, srcPath)
+	log.Printf("[docker]  CopyFromContainer: done err=%v", containerID)
+	return rc, err
+}
+
 // sinceUnix converts a duration string (e.g. "2h", "10m") to a Unix timestamp
 // string as required by the Docker API. Returns empty string if since is empty.
 func sinceUnix(since string) string {

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -314,14 +316,83 @@ func (s *mockContainerService) CopyFromContainer(
 	ctx context.Context,
 	containerID, srcPath string,
 ) (io.ReadCloser, error) {
+	var containerExists bool
+
 	for _, c := range s.containers {
 		if c.ID == containerID || c.Name == containerID {
-			//nolint:nilnil // we need a FileTree to use this
-			return nil, nil
+			containerExists = true
+			break
 		}
 	}
 
-	return nil, fmt.Errorf("container not found: %s", containerID)
+	if !containerExists {
+		return nil, fmt.Errorf("container not found: %s", containerID)
+	}
+
+	switch srcPath {
+	case "/etc":
+		return mockReaderCloser([]mockTarEntry{
+			{name: "etc", isDir: true},
+			{name: "etc/nginx.conf", isDir: false, content: "worker_processes 2;"},
+		})
+	case "/usr":
+		return mockReaderCloser([]mockTarEntry{
+			{name: "usr", isDir: true},
+			{name: "usr/bin", isDir: true},
+			{name: "usr/bin/cat", isDir: false, content: "cat binary"},
+		})
+	case "/etc/nginx.conf":
+		return mockReaderCloser([]mockTarEntry{
+			{name: "nginx.conf", isDir: false, content: "worker_processes 2;"},
+		})
+	case "/usr/bin":
+		return mockReaderCloser([]mockTarEntry{
+			{name: "bin", isDir: true},
+			{name: "bin/cat", isDir: false, content: "cat binary"},
+		})
+	default:
+		return nil, fmt.Errorf("no source path found %q in container %s", srcPath, containerID)
+	}
+}
+
+type mockTarEntry struct {
+	name    string
+	content string
+	isDir   bool
+}
+
+func mockReaderCloser(entries []mockTarEntry) (io.ReadCloser, error) {
+	var buf bytes.Buffer
+
+	tw := tar.NewWriter(&buf)
+	for _, entry := range entries {
+		hdr := &tar.Header{Name: entry.name}
+		if entry.isDir {
+			hdr.Typeflag = tar.TypeDir
+			hdr.Mode = 0o755
+			hdr.Size = 0
+		} else {
+			hdr.Typeflag = tar.TypeReg
+			hdr.Mode = 0o644
+			hdr.Size = int64(len(entry.content))
+		}
+
+		err := tw.WriteHeader(hdr)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = tw.Write([]byte(entry.content))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+
+	return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 }
 
 func (s *mockContainerService) Restart(ctx context.Context, id string) error {

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -310,6 +310,20 @@ func (s *mockContainerService) Unpause(ctx context.Context, containerID string) 
 	return fmt.Errorf("container not found: %s", containerID)
 }
 
+func (s *mockContainerService) CopyFromContainer(
+	ctx context.Context,
+	containerID, srcPath string,
+) (io.ReadCloser, error) {
+	for _, c := range s.containers {
+		if c.ID == containerID || c.Name == containerID {
+			//nolint:nilnil // we need a FileTree to use this
+			return nil, nil
+		}
+	}
+
+	return nil, fmt.Errorf("container not found: %s", containerID)
+}
+
 func (s *mockContainerService) Restart(ctx context.Context, id string) error {
 	for i, c := range s.containers {
 		if c.ID == id || c.Name == id {

--- a/internal/client/mock_test.go
+++ b/internal/client/mock_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"archive/tar"
 	"context"
+	"io"
 	"testing"
 )
 
@@ -95,5 +97,124 @@ func TestMockClient_ContainerExec(t *testing.T) {
 	output := string(buf[:n])
 	if output == "" {
 		t.Error("Read() returned empty output, want mock shell output")
+	}
+}
+
+func TestMockClient_CopyFromContainer(t *testing.T) {
+	client := NewMockClient()
+
+	tests := map[string]struct {
+		srcPath string
+		entries []mockTarEntry
+		wantErr bool
+	}{
+		"valid source path, copying etc directory": {
+			srcPath: "/etc",
+			entries: []mockTarEntry{
+				{name: "etc", isDir: true},
+				{name: "etc/nginx.conf", content: "worker_processes 2;"},
+			},
+		},
+		"valid source path, copying usr directory": {
+			srcPath: "/usr",
+			entries: []mockTarEntry{
+				{name: "usr", isDir: true},
+				{name: "usr/bin", isDir: true},
+				{name: "usr/bin/cat", content: "cat binary"},
+			},
+		},
+		"valid source path, copying nginx file": {
+			srcPath: "/etc/nginx.conf",
+			entries: []mockTarEntry{
+				{name: "nginx.conf", content: "worker_processes 2;"},
+			},
+		},
+		"valid source path, copying bin directory": {
+			srcPath: "/usr/bin",
+			entries: []mockTarEntry{
+				{name: "bin", isDir: true},
+				{name: "bin/cat", content: "cat binary"},
+			},
+		},
+		"invalid source path": {
+			srcPath: "/home/docker/.bashrc",
+			wantErr: true,
+		},
+	}
+
+	containers, err := client.Containers().List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	if len(containers) == 0 {
+		t.Fatal("expected at least one container")
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			rc, err := client.Containers().CopyFromContainer(
+				context.Background(),
+				containers[0].ID,
+				test.srcPath,
+			)
+
+			if test.wantErr {
+				if err == nil {
+					if rc != nil {
+						rc.Close()
+					}
+					t.Fatal("expected error copying from container")
+				}
+
+				if rc != nil {
+					t.Fatal("expected nil reader when error is returned")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error copying from container: %v", err)
+			}
+			defer rc.Close()
+
+			tr := tar.NewReader(rc)
+
+			for _, wantEntry := range test.entries {
+				hdr, err := tr.Next()
+				if err != nil {
+					t.Fatalf("error reading tar entry: %v", err)
+				}
+
+				if hdr.Name != wantEntry.name {
+					t.Errorf("expected header name %q, got %q", wantEntry.name, hdr.Name)
+				}
+
+				if wantEntry.isDir {
+					if hdr.Typeflag != tar.TypeDir {
+						t.Errorf("expected %q to be a directory", wantEntry.name)
+					}
+
+					if hdr.Size != 0 {
+						t.Errorf("expected directory %q size to be 0, got %d", wantEntry.name, hdr.Size)
+					}
+					continue
+				}
+
+				if hdr.Typeflag != tar.TypeReg {
+					t.Errorf("expected %q to be a file", wantEntry.name)
+				}
+
+				data, err := io.ReadAll(tr)
+				if err != nil {
+					t.Fatalf("error reading tar file %q: %v", hdr.Name, err)
+				}
+
+				if string(data) != wantEntry.content {
+					t.Errorf("expected content %q, got %q", wantEntry.content, string(data))
+				}
+			}
+		})
 	}
 }

--- a/internal/ui/helper/helper.go
+++ b/internal/ui/helper/helper.go
@@ -105,7 +105,7 @@ func ExtractTarToWorkingDir(dst string, r io.Reader) error {
 	tr := tar.NewReader(r)
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 

--- a/internal/ui/helper/helper.go
+++ b/internal/ui/helper/helper.go
@@ -1,13 +1,20 @@
 package helper
 
 import (
+	"archive/tar"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	"golang.org/x/exp/constraints"
 )
+
+const maxCopySize = 1 * 1024 * 1024 // 1MB
 
 const shortIDLength = 12 // length of shortened container/image IDs
 
@@ -93,4 +100,54 @@ func StripCommand(cmd string) string {
 	cmd = strings.TrimPrefix(cmd, "/bin/sh -c ")
 	cmd = strings.TrimPrefix(cmd, "#(nop) ")
 	return strings.Join(strings.Fields(cmd), " ")
+}
+func ExtractTarToWorkingDir(dst string, r io.Reader) error {
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		// dir/file where it should be created
+		target := filepath.Join(dst, hdr.Name) //nolint:gosec //  path traversal prevented by HasPrefix
+		if !strings.HasPrefix(filepath.Clean(target), filepath.Clean(dst)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid path: %s", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if _, err = os.Stat(target); err != nil {
+				if err = os.MkdirAll(target, 0750); err != nil {
+					return err
+				}
+			}
+
+		case tar.TypeReg:
+			var f *os.File
+			//nolint:gosec // hdr.Mode max value 0777 fits safely in uint32
+			f, err = os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(hdr.Mode))
+			if err != nil {
+				return err
+			}
+
+			for {
+				_, err = io.CopyN(f, tr, maxCopySize)
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						break
+					}
+
+					return err
+				}
+			}
+			_ = f.Close()
+		}
+	}
+
+	return nil
 }

--- a/internal/ui/helper/helper_test.go
+++ b/internal/ui/helper/helper_test.go
@@ -1,6 +1,10 @@
 package helper
 
 import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -257,5 +261,61 @@ func TestStripCommand(t *testing.T) {
 				t.Errorf("StripCommand(%q) = %q, want %q", tt.cmd, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExtractTarToWorkingDir(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	entries := []struct {
+		hdr  *tar.Header
+		body string
+	}{
+		{&tar.Header{Name: "mydir/", Typeflag: tar.TypeDir, Mode: 0755}, ""},
+		{&tar.Header{Name: "mydir/docker.txt", Typeflag: tar.TypeReg, Mode: 0600, Size: 6}, "helloo"},
+		{&tar.Header{Name: "mydir/dash.txt", Typeflag: tar.TypeReg, Mode: 0600, Size: 5}, "world"},
+	}
+
+	for _, e := range entries {
+		if err := tw.WriteHeader(e.hdr); err != nil {
+			t.Fatal(err)
+		}
+		if e.body != "" {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	tw.Close()
+
+	destDir := t.TempDir()
+	if err := ExtractTarToWorkingDir(destDir, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(destDir, "mydir"))
+	if err != nil {
+		t.Fatalf("dir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("expected a directory")
+	}
+
+	cases := []struct{ name, want string }{
+		{"mydir/docker.txt", "helloo"},
+		{"mydir/dash.txt", "world"},
+	}
+
+	for _, c := range cases {
+		b, err := os.ReadFile(filepath.Join(destDir, c.name))
+		if err != nil {
+			t.Errorf("file %q not found: %v", c.name, err)
+			continue
+		}
+
+		if string(b) != c.want {
+			t.Errorf("file %q: got %q, want %q", c.name, string(b), c.want)
+		}
 	}
 }

--- a/internal/ui/keys/keys.go
+++ b/internal/ui/keys/keys.go
@@ -44,6 +44,8 @@ type KeyMap struct {
 	LogScrollLeft  key.Binding
 	LogScrollRight key.Binding
 
+	CpFromContainerToHost key.Binding
+
 	Prune key.Binding
 
 	SystemInfo key.Binding
@@ -202,6 +204,10 @@ var Keys = &KeyMap{
 	Prune: key.NewBinding(
 		key.WithKeys("P"),
 		key.WithHelp("P", "prune"),
+	),
+	CpFromContainerToHost: key.NewBinding(
+		key.WithKeys("c"),
+		key.WithHelp("c", "copy from container to host"),
 	),
 	SystemInfo: key.NewBinding(
 		key.WithKeys("alt+i"),

--- a/internal/ui/sections/containers/files_panel.go
+++ b/internal/ui/sections/containers/files_panel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -33,6 +34,7 @@ type filesPanel struct {
 	service       client.ContainerService
 	loading       bool
 	width, height int
+	containerID   string
 	root          *client.FileNode
 	visible       []*client.FileNode
 	cursor        int
@@ -47,12 +49,13 @@ func (f *filesPanel) Name() string {
 	return "Files"
 }
 
-func (f *filesPanel) Init(item sections.ListItem) tea.Cmd {
-	log.Printf("[containers][files-panel] Init: containerID=%q", item.ID())
+func (f *filesPanel) Init(listItem sections.ListItem) tea.Cmd {
+	f.containerID = listItem.ID()
+	log.Printf("[containers][files-panel] Init: containerID=%q", f.containerID)
 	f.loading = true
 	f.requestID++
 	requestID := f.requestID
-	return tea.Batch(f.showSpinnerCmd(requestID), f.fetchCmd(item.ID(), requestID), f.extendHelpCmd())
+	return tea.Batch(f.showSpinnerCmd(requestID), f.fetchCmd(f.containerID, requestID), f.extendHelpCmd())
 }
 
 func computeVisible(root *client.FileNode) []*client.FileNode {
@@ -114,6 +117,9 @@ func (f *filesPanel) Update(msg tea.Msg) tea.Cmd {
 					}
 				}
 			}
+		case key.Matches(msg, keys.Keys.CpFromContainerToHost):
+			node := f.visible[f.cursor]
+			return tea.Batch(f.copyFromContainerCmd(node))
 		}
 	}
 
@@ -225,6 +231,44 @@ func (f *filesPanel) fetchCmd(containerID string, requestID int) tea.Cmd {
 			return fileNodeLoadedMsg{requestID: requestID, err: fmt.Errorf("error getting the file tree: %w", err)}
 		}
 		return fileNodeLoadedMsg{requestID: requestID, fileNode: fileNode}
+	}
+}
+
+func (f *filesPanel) copyFromContainerCmd(node *client.FileNode) tea.Cmd {
+	ctx := f.ctx
+	svc := f.service
+	containerID := f.containerID
+	srcPath := node.Path
+
+	return func() tea.Msg {
+		rc, err := svc.CopyFromContainer(ctx, containerID, srcPath)
+		if err != nil {
+			return message.ShowBannerMsg{
+				Message: fmt.Sprintf("error copying %q from container %q: %v", srcPath, containerID, err),
+				IsError: true,
+			}
+		}
+		defer rc.Close()
+
+		dstDir, err := os.Getwd()
+		if err != nil {
+			return message.ShowBannerMsg{
+				Message: fmt.Sprintf("error getting current dir: %v", err),
+				IsError: true,
+			}
+		}
+
+		if err = helper.ExtractTarToWorkingDir(dstDir, rc); err != nil {
+			return message.ShowBannerMsg{
+				Message: fmt.Sprintf("error extracting tar to %q: %v", srcPath, err),
+				IsError: true,
+			}
+		}
+
+		return message.ShowBannerMsg{
+			Message: fmt.Sprintf("%s got copied to host succesfully", srcPath),
+			IsError: false,
+		}
 	}
 }
 

--- a/internal/ui/sections/containers/files_panel.go
+++ b/internal/ui/sections/containers/files_panel.go
@@ -119,7 +119,7 @@ func (f *filesPanel) Update(msg tea.Msg) tea.Cmd {
 			}
 		case key.Matches(msg, keys.Keys.CpFromContainerToHost):
 			node := f.visible[f.cursor]
-			return tea.Batch(f.copyFromContainerCmd(node))
+			return f.copyFromContainerCmd(node)
 		}
 	}
 

--- a/internal/ui/sections/containers/files_panel_test.go
+++ b/internal/ui/sections/containers/files_panel_test.go
@@ -297,3 +297,45 @@ func TestFileTreePanelCursorNavigation(t *testing.T) {
 		t.Errorf("up arrow should move cursor back to 0, got %d", p.cursor)
 	}
 }
+
+func TestCopyFromContainer(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	p := newTestFileTreePanel()
+	p.SetSize(80, 40)
+
+	containerID := "abc123def456"
+	cmd := p.Init(containerItem{container: client.Container{ID: containerID}})
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Init() cmd returned %T, want tea.BatchMsg", cmd())
+	}
+	for _, c := range batch {
+		p.Update(c())
+	}
+
+	if len(p.visible) < 2 {
+		t.Skip("need at least 2 visible nodes for cursor navigation test")
+	}
+
+	if p.cursor != 0 {
+		t.Fatalf("cursor should start at 0, got %d", p.cursor)
+	}
+
+	p.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if p.cursor != 1 {
+		t.Errorf("down arrow should move cursor to 1, got %d", p.cursor)
+	}
+
+	cpFromContainerKey := rune('c')
+	cmd = p.Update(tea.KeyPressMsg{Code: cpFromContainerKey})
+	showBannerMsg, ok := cmd().(message.ShowBannerMsg)
+	if !ok {
+		t.Fatalf("copyFromContainerCmd() returned %T, want message.ShowBannerMsg", cmd())
+	}
+
+	if showBannerMsg.IsError {
+		t.Errorf("unexpected error copying from container %s", containerID)
+	}
+}


### PR DESCRIPTION
No mock complete implementation because we need a `FileTree` and we don't have one.
part of #71